### PR TITLE
Alma oops

### DIFF
--- a/client/e2e/alma-oops.spec.ts
+++ b/client/e2e/alma-oops.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+// Verifies navigation to the new ALMA OOPS page works without crashing.
+test.describe("ALMA OOPS page", () => {
+  test("navigates from the dashboard to ALMA OOPS", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Automation Dashboard")).toBeVisible();
+
+    await page.getByRole("button", { name: "Alma oops" }).click();
+
+    // Page header renders (scoped to <header> to avoid matching the nav button).
+    await expect(page.locator("header").getByText("Alma oops")).toBeVisible();
+
+    // The view settles into one of its valid states: failure cards with an
+    // occurrences badge, the empty state, or an error.
+    const occurrences = page.getByText(/Occurred \d+ time/i);
+    const empty = page.getByText(/No Alma oops failures/i);
+    const errored = page.getByText(/failed to load/i);
+    await expect(occurrences.or(empty).or(errored).first()).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import RecentFailuresPage from './pages/Recentfailurespage';
 import AreaHealthPage from './pages/AreaHealthPage';
 import CommonFailuresPage from './pages/CommonFailuresPage';
 import TestHistoryPage from './pages/TestHistoryPage';
+import AlmaOopsPage from './pages/AlmaOopsPage';
 import BackToTopButton from './components/BackToTopButton';
 import ThemeModeProvider from './components/ThemeModeProvider';
 
@@ -16,6 +17,7 @@ function App() {
           <Route path="/failures/:areaName" element={<RecentFailuresPage />} />
           <Route path="/health/:areaName/:bucket" element={<AreaHealthPage />} />
           <Route path="/common-failures" element={<CommonFailuresPage />} />
+        <Route path="/alma-oops" element={<AlmaOopsPage />} />
           <Route path="/area/:areaName/test/:testName/history" element={<TestHistoryPage />} />
         </Routes>
         <BackToTopButton />

--- a/client/src/components/ByReasonView.tsx
+++ b/client/src/components/ByReasonView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Typography, Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import FailureCard from "./FailureCard";
+import FailureRowList from "./FailureRowList";
 import type { ReasonGroup } from "../types/FailuresByReason";
 
 interface ByReasonViewProps {
@@ -57,21 +57,16 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
               {group.failCount} {group.failCount === 1 ? "test" : "tests"}
             </Box>
           </AccordionSummary>
-          <AccordionDetails sx={{ p: 2, bgcolor: "background.default" }}>
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.75 }}>
-              {group.tests.map((item, i) => (
-                <FailureCard
-                  key={item.testName}
-                  item={item}
-                  index={i}
-                  onImageClick={onImageClick}
-                  onExpandLog={onExpandLog}
-                  onOpenHistory={() => onOpenHistory(item.testName)}
-                  testRailUrl={testRailUrlFor(item.testName)}
-                  areaName={areaName}
-                />
-              ))}
-            </Box>
+          <AccordionDetails sx={{ p: 0 }}>
+            {/* Compact rows — same layout as the By Server / By Job tabs. */}
+            <FailureRowList
+              items={group.tests}
+              onImageClick={onImageClick}
+              onExpandLog={onExpandLog}
+              onOpenHistory={onOpenHistory}
+              testRailUrlFor={testRailUrlFor}
+              areaName={areaName}
+            />
           </AccordionDetails>
         </Accordion>
       ))}

--- a/client/src/components/SearchWithHistory.tsx
+++ b/client/src/components/SearchWithHistory.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import {
+  Box, TextField, InputAdornment, IconButton, Paper, List, ListItem,
+  ListItemButton, ListItemText, ClickAwayListener,
+} from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
+import HistoryIcon from "@mui/icons-material/History";
+import { useSearchHistory } from "../hooks/useSearchHistory";
+
+interface SearchWithHistoryProps {
+  value: string;
+  onSearch: (value: string) => void;
+  storageKey: string;
+  placeholder?: string;
+  fullWidth?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+const SearchWithHistory: React.FC<SearchWithHistoryProps> = ({
+  value, onSearch, storageKey, placeholder = "Search…", fullWidth = false, sx,
+}) => {
+  const { history, remove, push } = useSearchHistory(storageKey);
+  const [open, setOpen] = useState(false);
+
+  const applyHistory = (term: string) => {
+    onSearch(term);
+    push(term);
+    setOpen(false);
+  };
+
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Box sx={{ position: "relative", width: fullWidth ? "100%" : "auto", ...(sx as object) }}>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder={placeholder}
+          value={value}
+          onFocus={() => setOpen(true)}
+          onClick={() => setOpen(true)}
+          onChange={(e) => onSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" sx={{ color: "text.disabled" }} />
+              </InputAdornment>
+            ),
+            endAdornment: value ? (
+              <InputAdornment position="end">
+                <IconButton size="small" aria-label="Clear search" onClick={() => onSearch("")}>
+                  <CloseIcon fontSize="small" sx={{ color: "text.disabled" }} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+          }}
+          sx={{ "& .MuiOutlinedInput-root": { bgcolor: "background.paper" }, "& .MuiOutlinedInput-input": { color: "text.primary" } }}
+        />
+
+        {open && value.trim() === "" && history.length > 0 && (
+          <Paper
+            elevation={8}
+            data-testid="search-history-dropdown"
+            sx={{
+              position: "absolute",
+              top: "100%",
+              left: 0,
+              width: "100%",
+              mt: 0.5,
+              zIndex: 1300,
+              bgcolor: "background.paper",
+              border: 1,
+              borderColor: "divider",
+              boxShadow: "0 8px 28px rgba(0,0,0,0.25)",
+            }}
+          >
+            <List dense disablePadding sx={{ maxHeight: 250, overflowY: "auto" }} data-testid="search-history-list">
+              {history.map((term) => (
+                <ListItem
+                  key={term}
+                  disablePadding
+                  secondaryAction={
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      aria-label={`Remove ${term} from history`}
+                      onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                      onClick={(e) => { e.stopPropagation(); remove(term); }}
+                    >
+                      <CloseIcon fontSize="small" sx={{ color: "text.disabled" }} />
+                    </IconButton>
+                  }
+                >
+                  <ListItemButton
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => applyHistory(term)}
+                    sx={{ pr: 6 }}
+                  >
+                    <HistoryIcon fontSize="small" sx={{ color: "text.disabled", mr: 1 }} />
+                    <ListItemText primary={term} primaryTypographyProps={{ noWrap: true, fontSize: 13, color: "text.primary" }} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          </Paper>
+        )}
+      </Box>
+    </ClickAwayListener>
+  );
+};
+
+export default SearchWithHistory;

--- a/client/src/components/__tests__/SearchWithHistory.test.tsx
+++ b/client/src/components/__tests__/SearchWithHistory.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SearchWithHistory from "../SearchWithHistory";
+
+const KEY = "searchHistory:test";
+
+function seed(items: string[]) {
+  localStorage.setItem(KEY, JSON.stringify(items));
+}
+
+describe("SearchWithHistory", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("calls onSearch as the user types", () => {
+    const onSearch = vi.fn();
+    render(<SearchWithHistory value="" onSearch={onSearch} storageKey={KEY} placeholder="Search…" />);
+    fireEvent.change(screen.getByPlaceholderText("Search…"), { target: { value: "x" } });
+    expect(onSearch).toHaveBeenCalledWith("x");
+  });
+
+  it("shows the history dropdown on focus", () => {
+    seed(["alpha", "beta"]);
+    render(<SearchWithHistory value="" onSearch={() => {}} storageKey={KEY} placeholder="Search…" />);
+    fireEvent.focus(screen.getByPlaceholderText("Search…"));
+    const list = screen.getByTestId("search-history-list");
+    expect(list).toHaveTextContent("alpha");
+    expect(list).toHaveTextContent("beta");
+  });
+
+  it("applies a history term when clicked", () => {
+    seed(["alpha"]);
+    const onSearch = vi.fn();
+    render(<SearchWithHistory value="" onSearch={onSearch} storageKey={KEY} placeholder="Search…" />);
+    fireEvent.focus(screen.getByPlaceholderText("Search…"));
+    fireEvent.click(screen.getByText("alpha"));
+    expect(onSearch).toHaveBeenCalledWith("alpha");
+  });
+
+  it("removes a single history item via its X button without closing the dropdown", () => {
+    seed(["alpha", "beta"]);
+    render(<SearchWithHistory value="" onSearch={() => {}} storageKey={KEY} placeholder="Search…" />);
+    fireEvent.focus(screen.getByPlaceholderText("Search…"));
+    fireEvent.click(screen.getByLabelText("Remove alpha from history"));
+
+    const list = screen.getByTestId("search-history-list");
+    expect(list).not.toHaveTextContent("alpha");
+    expect(list).toHaveTextContent("beta");
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["beta"]);
+  });
+});

--- a/client/src/hooks/__tests__/useSearchHistory.test.ts
+++ b/client/src/hooks/__tests__/useSearchHistory.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSearchHistory } from "../useSearchHistory";
+
+const KEY = "searchHistory:test";
+
+describe("useSearchHistory", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("pushes newest first and persists to localStorage", () => {
+    const { result } = renderHook(() => useSearchHistory(KEY));
+    act(() => result.current.push("alpha"));
+    act(() => result.current.push("beta"));
+
+    expect(result.current.history).toEqual(["beta", "alpha"]);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["beta", "alpha"]);
+  });
+
+  it("keeps only the 10 most recent unique terms", () => {
+    const { result } = renderHook(() => useSearchHistory(KEY));
+    act(() => {
+      for (let i = 1; i <= 12; i++) result.current.push(`term${i}`);
+    });
+
+    expect(result.current.history).toHaveLength(10);
+    expect(result.current.history[0]).toBe("term12");
+    expect(result.current.history).not.toContain("term1");
+    expect(result.current.history).not.toContain("term2");
+  });
+
+  it("de-duplicates (case-insensitive) and promotes the repeated term", () => {
+    const { result } = renderHook(() => useSearchHistory(KEY));
+    act(() => result.current.push("alpha"));
+    act(() => result.current.push("beta"));
+    act(() => result.current.push("ALPHA"));
+
+    expect(result.current.history).toEqual(["ALPHA", "beta"]);
+  });
+
+  it("removes a specific term and updates localStorage", () => {
+    const { result } = renderHook(() => useSearchHistory(KEY));
+    act(() => result.current.push("alpha"));
+    act(() => result.current.push("beta"));
+    act(() => result.current.remove("alpha"));
+
+    expect(result.current.history).toEqual(["beta"]);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["beta"]);
+  });
+
+  it("ignores empty / whitespace terms", () => {
+    const { result } = renderHook(() => useSearchHistory(KEY));
+    act(() => result.current.push("   "));
+    expect(result.current.history).toEqual([]);
+  });
+});

--- a/client/src/hooks/useSearchHistory.ts
+++ b/client/src/hooks/useSearchHistory.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+
+const MAX_ITEMS = 10;
+const CHANGE_EVENT = "searchhistory-change";
+
+function read(storageKey: string): string[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persistent search history (localStorage). Keeps the 10 most recent unique terms,
+ * newest first. `push` adds/promotes a term; `remove` deletes a specific term.
+ * A window event keeps independent instances (e.g. the dropdown and a parent that
+ * saves selected results) in sync.
+ */
+export function useSearchHistory(storageKey: string) {
+  const [history, setHistory] = useState<string[]>(() => read(storageKey));
+
+  useEffect(() => {
+    const refresh = () => setHistory(read(storageKey));
+    refresh();
+
+    const onChange = (e: Event) => {
+      const key = (e as CustomEvent<{ key: string }>).detail?.key;
+      if (!key || key === storageKey) refresh();
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === null || e.key === storageKey) refresh();
+    };
+
+    window.addEventListener(CHANGE_EVENT, onChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [storageKey]);
+
+  const write = useCallback((next: string[]) => {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(next));
+    } catch {
+      /* ignore storage errors */
+    }
+    setHistory(next);
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { key: storageKey } }));
+  }, [storageKey]);
+
+  const push = useCallback((term: string) => {
+    const trimmed = term.trim();
+    if (!trimmed) return;
+    const prev = read(storageKey);
+    const deduped = prev.filter((t) => t.toLowerCase() !== trimmed.toLowerCase());
+    write([trimmed, ...deduped].slice(0, MAX_ITEMS));
+  }, [storageKey, write]);
+
+  const remove = useCallback((term: string) => {
+    const prev = read(storageKey);
+    write(prev.filter((t) => t !== term));
+  }, [storageKey, write]);
+
+  return { history, push, remove };
+}

--- a/client/src/pages/AlmaOopsPage.tsx
+++ b/client/src/pages/AlmaOopsPage.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Box, Typography, Button, Alert, CircularProgress, Chip } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EnvToggle from "../components/EnvToggle";
+import ThemeToggle from "../components/ThemeToggle";
+import SearchInput from "../components/SearchInput";
+import FailureCard from "../components/FailureCard";
+import ImageModal from "../components/ImageModal";
+import LogModal from "../components/LogModal";
+import { getAlmaOops, type EnvFilter } from "../services/apiService";
+import type { AlmaOopsItem } from "../types/AlmaOops";
+
+const AlmaOopsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [env, setEnv] = useState<EnvFilter>(
+    () => (localStorage.getItem("selectedEnv") as EnvFilter) ?? "qa"
+  );
+  const [items, setItems] = useState<AlmaOopsItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [logModal, setLogModal] = useState<{ lines: string[]; testName: string; label: string } | null>(null);
+
+  const handleEnvChange = (e: EnvFilter) => {
+    setEnv(e);
+    localStorage.setItem("selectedEnv", e);
+  };
+
+  const openHistory = (area: string, testName: string) => {
+    navigate(`/area/${encodeURIComponent(area)}/test/${encodeURIComponent(testName)}/history?env=${env}`);
+  };
+
+  // Client-side filter on job name, server, or error message (also test/area).
+  const q = search.trim().toLowerCase();
+  const filtered = q
+    ? items.filter(it =>
+        (it.jobName ?? "").toLowerCase().includes(q) ||
+        (it.lastFailure.server ?? "").toLowerCase().includes(q) ||
+        (it.reasons[0]?.text ?? "").toLowerCase().includes(q) ||
+        it.testName.toLowerCase().includes(q) ||
+        it.area.toLowerCase().includes(q)
+      )
+    : items;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    getAlmaOops(env)
+      .then(d => { if (!cancelled) setItems(d.items); })
+      .catch(e => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load Alma oops"); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [env]);
+
+  return (
+    <Box sx={{ minHeight: "100vh", bgcolor: "background.default" }}>
+      {imageSrc && <ImageModal src={imageSrc} onClose={() => setImageSrc(null)} />}
+      {logModal && (
+        <LogModal lines={logModal.lines} testName={logModal.testName} reasonLabel={logModal.label}
+          onClose={() => setLogModal(null)} />
+      )}
+
+      {/* ── Sticky header ── */}
+      <Box component="header" sx={{
+        bgcolor: "background.paper", borderBottom: 1, borderColor: "divider",
+        px: 4, py: 1.75, display: "flex", alignItems: "center", gap: 2,
+        position: "sticky", top: 0, zIndex: 100, boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+      }}>
+        <Button
+          variant="outlined" size="small" startIcon={<ArrowBackIcon />}
+          onClick={() => navigate("/")}
+          sx={{ borderColor: "divider", color: "text.secondary", textTransform: "none" }}
+        >
+          Dashboard
+        </Button>
+        <Box sx={{ flex: 1 }}>
+          <Typography sx={{ fontSize: 26, fontWeight: 900, color: "text.primary", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "-0.02em", lineHeight: 1.15 }}>
+            Alma oops
+          </Typography>
+          <Typography variant="caption" sx={{ color: "text.secondary" }}>
+            "Message appear" popup failures · last 10 days · {env.toUpperCase()}
+          </Typography>
+        </Box>
+        <EnvToggle value={env} onChange={handleEnvChange} />
+        {!loading && !error && (
+          <Box sx={{ bgcolor: "background.default", border: 1, borderColor: "divider", borderRadius: 2.5, px: 2.25, py: 0.75, textAlign: "center" }}>
+            <Typography sx={{ fontSize: 20, fontWeight: 800, color: "text.primary" }}>{items.length}</Typography>
+            <Typography sx={{ fontSize: 11, color: "text.secondary" }}>oops</Typography>
+          </Box>
+        )}
+        <ThemeToggle />
+      </Box>
+
+      {/* ── Content ── */}
+      <Box sx={{ p: "24px 40px" }}>
+        {loading && (
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5, py: 8, color: "text.secondary" }}>
+            <CircularProgress size={28} />
+            <Typography>Loading Alma Oops…</Typography>
+          </Box>
+        )}
+
+        {!loading && error && <Alert severity="error">{error}</Alert>}
+
+        {!loading && !error && items.length === 0 && (
+          <Alert severity="success">🎉 No Alma oops failures in the last 10 days!</Alert>
+        )}
+
+        {!loading && !error && items.length > 0 && (
+          <>
+            <Box sx={{ display: "flex", gap: 1.5, mb: 2.5, alignItems: "center" }}>
+              <SearchInput
+                value={search}
+                onChange={setSearch}
+                placeholder="Search"
+                sx={{ maxWidth: 480, flex: 1 }}
+              />
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>{filtered.length} results</Typography>
+            </Box>
+
+            {filtered.length === 0 ? (
+              <Alert severity="info">No Alma oops match <strong>"{search}"</strong></Alert>
+            ) : (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.75 }}>
+                {filtered.map((item, i) => (
+              <Box key={`${item.area}-${item.testName}`}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+                  <Chip label={item.area} size="small" variant="outlined" sx={{ fontSize: 11, color: "text.secondary", borderColor: "divider" }} />
+                  <Chip label={`Occurred ${item.occurrences} ${item.occurrences === 1 ? "time" : "times"}`} size="small"
+                    sx={{ fontSize: 11, fontWeight: 700, bgcolor: "#1e293b", color: "#f1f5f9" }} />
+                </Box>
+                <FailureCard
+                  item={item}
+                  index={i}
+                  onImageClick={setImageSrc}
+                  onExpandLog={(lines, testName, label) => setLogModal({ lines, testName, label })}
+                  onOpenHistory={() => openHistory(item.area, item.testName)}
+                  areaName={item.area}
+                />
+              </Box>
+                ))}
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default AlmaOopsPage;

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -150,8 +150,29 @@ const DashboardPage: React.FC = () => {
       {/* Header row: 3-column layout keeps the center content truly centered */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 4 }}>
 
-        {/* Left: nav button, vertically aligned with the env toggle */}
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start', pt: '68px' }}>
+        {/* Left: nav buttons, vertically aligned with the env toggle */}
+        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start', gap: 1.25, pt: '68px' }}>
+          <Button
+            variant="contained"
+            onClick={() => navigate("/alma-oops")}
+            sx={{
+              textTransform: "none",
+              fontSize: 13,
+              fontWeight: 600,
+              borderRadius: 2,
+              px: 2.5,
+              py: 0.9,
+              backgroundColor: "#1e293b",
+              color: "#f1f5f9",
+              boxShadow: "none",
+              "&:hover": {
+                backgroundColor: "#334155",
+                boxShadow: "0 2px 8px rgba(0,0,0,0.18)",
+              },
+            }}
+          >
+            Alma oops
+          </Button>
           <Button
             variant="contained"
             onClick={() => navigate("/common-failures")}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -17,12 +17,13 @@ import {
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import SearchIcon from "@mui/icons-material/Search";
-import SearchInput from "../components/SearchInput";
+import SearchWithHistory from "../components/SearchWithHistory";
 import ThemeToggle from "../components/ThemeToggle";
 
 import AreaCard from "../components/AreaCard";
 import EnvToggle from "../components/EnvToggle";
 import { useFavorites } from "../hooks/useFavorites";
+import { useSearchHistory } from "../hooks/useSearchHistory";
 import {
   getAreas,
   getAreasDashboard,
@@ -51,6 +52,7 @@ const DashboardPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const { toggleFavorite, isFavorite } = useFavorites();
+  const { push: pushSearchHistory } = useSearchHistory("dashboard-search-history");
   const [env, setEnv] = useState<EnvFilter>(
     () => (localStorage.getItem("selectedEnv") as EnvFilter) ?? "qa"
   );
@@ -234,7 +236,7 @@ const DashboardPage: React.FC = () => {
         sx={{
           mb: 4,
           borderRadius: 3,
-          overflow: "hidden",
+          overflow: "visible",
           bgcolor: "background.paper",
         }}
       >
@@ -243,21 +245,13 @@ const DashboardPage: React.FC = () => {
             <Box sx={{ width: 42, height: 42, borderRadius: 2, display: "grid", placeItems: "center", bgcolor: "#eff6ff", color: "#1d4ed8" }}>
               <SearchIcon />
             </Box>
-            <Box sx={{ flex: 1 }}>
-              <SearchInput
+            <Box sx={{ flex: 1, maxWidth: 420 }}>
+              <SearchWithHistory
                 fullWidth
                 value={testQuery}
-                onChange={setTestQuery}
+                onSearch={setTestQuery}
+                storageKey="dashboard-search-history"
                 placeholder="Search tests across all areas…"
-                sx={{
-                  maxWidth: 420,
-                  "& .MuiOutlinedInput-root": {
-                    borderRadius: 2,
-                    "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#cbd5e1" },
-                    "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#3b82f6" },
-                  },
-                  "& .MuiOutlinedInput-input::placeholder": { opacity: 0.6 },
-                }}
               />
             </Box>
           </Box>
@@ -283,7 +277,7 @@ const DashboardPage: React.FC = () => {
                   {testResults.map((result) => (
                     <ListItemButton
                       key={`${result.area}-${result.testName}`}
-                      onClick={() => openTestHistory(result.area, result.testName)}
+                      onClick={() => { pushSearchHistory(result.testName); openTestHistory(result.area, result.testName); }}
                       sx={{ py: 1.35, px: 2, borderBottom: "1px solid #f1f5f9", "&:last-child": { borderBottom: 0 } }}
                     >
                       <ListItemText

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -383,7 +383,7 @@ const RecentFailuresPage: React.FC = () => {
         {activeTab === 1 && latestData && (
           <Box sx={{ bgcolor: "#fef2f2", border: "1px solid #fecaca", borderRadius: 2.5, px: 2.25, py: 0.75, textAlign: "center" }}>
             <Typography sx={{ fontSize: 20, fontWeight: 800, color: "#dc2626" }}>{latestData.totalCount}</Typography>
-            <Typography sx={{ fontSize: 11, color: "#ef4444" }}>broken now</Typography>
+            <Typography sx={{ fontSize: 11, color: "#ef4444" }}>failed tests</Typography>
           </Box>
         )}
         {activeTab === 2 && data && (

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -3,8 +3,10 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Box, Typography, Button,
   Collapse, ToggleButtonGroup, ToggleButton, Paper, Skeleton, Alert,
+  Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -26,6 +28,22 @@ import type { LatestFailedTestsResponse } from "../types/LatestFailed";
 import type { AreaFailuresByReasonResponse } from "../types/FailuresByReason";
 
 const LIMIT = 200;
+
+// Shared styling for the collapsible group accordions (By Server / By Job).
+const accordionSx = {
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  borderRadius: 2,
+  overflow: "hidden",
+  "&:before": { display: "none" },
+  boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+} as const;
+
+const accordionSummarySx = {
+  bgcolor: "#1e293b",
+  "& .MuiAccordionSummary-content": { alignItems: "center", gap: 1.5, my: 1.25, minWidth: 0 },
+} as const;
 
 function buildTestHistoryPath(areaName: string, testName: string, env: EnvFilter): string {
   return `/area/${encodeURIComponent(areaName)}/test/${encodeURIComponent(testName)}/history?env=${env}`;
@@ -77,24 +95,17 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
       {filteredServers.map((serverGroup) => (
-        <Box key={serverGroup.server}>
-          {/* Server header */}
-          <Box sx={{
-            display: "flex", alignItems: "center", gap: 1.5,
-            px: 2.25, py: 1.5,
-            bgcolor: "#1e293b",
-            borderRadius: "8px 8px 0 0",
-            borderBottom: "3px solid #ef4444",
-          }}>
+        <Accordion key={serverGroup.server} disableGutters sx={accordionSx}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />} sx={accordionSummarySx}>
             <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🖥️</Typography>
-            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em" }}>
+            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
               {serverGroup.server}
             </Typography>
-            <Box component="span" sx={{ ml: "auto", bgcolor: "#ef4444", color: "#fff", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
+            <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
               {serverGroup.tests.length} {serverGroup.tests.length === 1 ? "test" : "tests"}
             </Box>
-          </Box>
-
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
           {/* Test list */}
           <Paper variant="outlined" sx={{ borderTop: "none", borderRadius: "0 0 8px 8px", overflow: "hidden" }}>
             {serverGroup.tests.map((test, idx) => {
@@ -201,7 +212,8 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
               );
             })}
           </Paper>
-        </Box>
+          </AccordionDetails>
+        </Accordion>
       ))}
     </Box>
   );
@@ -504,33 +516,27 @@ const RecentFailuresPage: React.FC = () => {
             {!loading && !error && jobGroups.length > 0 && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
                 {jobGroups.map(group => (
-                  <Box key={group.job}>
-                    {/* Job header */}
-                    <Box sx={{
-                      display: "flex", alignItems: "center", gap: 1.5,
-                      px: 2.25, py: 1.5,
-                      bgcolor: "#1e293b",
-                      borderRadius: "8px 8px 0 0",
-                      borderBottom: "3px solid #475569",
-                    }}>
+                  <Accordion key={group.job} disableGutters sx={accordionSx}>
+                    <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />} sx={accordionSummarySx}>
                       <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🛠️</Typography>
-                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", wordBreak: "break-all" }}>
+                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                         {group.job}
                       </Typography>
-                      <Box component="span" sx={{ ml: "auto", bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700, flexShrink: 0 }}>
+                      <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
                         {group.items.length} {group.items.length === 1 ? "test" : "tests"}
                       </Box>
-                    </Box>
-                    {/* Compact rows (same look as List View) */}
-                    <FailureRowList
-                      items={group.items}
-                      onImageClick={setImageSrc}
-                      onExpandLog={(lines, testName, label) => setLogModal({ lines, testName, label })}
-                      onOpenHistory={openTestHistory}
-                      testRailUrlFor={testRailUrlFor}
-                      areaName={areaName}
-                    />
-                  </Box>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 0 }}>
+                      <FailureRowList
+                        items={group.items}
+                        onImageClick={setImageSrc}
+                        onExpandLog={(lines, testName, label) => setLogModal({ lines, testName, label })}
+                        onOpenHistory={openTestHistory}
+                        testRailUrlFor={testRailUrlFor}
+                        areaName={areaName}
+                      />
+                    </AccordionDetails>
+                  </Accordion>
                 ))}
               </Box>
             )}

--- a/client/src/pages/__tests__/AlmaOopsPage.test.tsx
+++ b/client/src/pages/__tests__/AlmaOopsPage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import * as api from "../../services/apiService";
+import AlmaOopsPage from "../AlmaOopsPage";
+
+vi.mock("../../services/apiService", () => ({
+  getAlmaOops: vi.fn(),
+  // FailureCard imports this; not exercised here but must exist on the mock.
+  getExpandedLog: vi.fn(() => new Promise(() => {})),
+}));
+
+const oopsItem = {
+  area: "LOD",
+  testName: "Oops_Test_1",
+  occurrences: 5,
+  failCount: 5,
+  lastFailedOn: "2026-06-10",
+  jobName: null,
+  reasons: [{ text: "FATAL Message appear", lastDate: "2026-06-10", screenshotLink: null, logLink: null }],
+  lastFailure: { server: "QAC01", almaVersion: null, buildNumber: null, logLink: null, screenshotLink: null },
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AlmaOopsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AlmaOopsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows a loading indicator before data resolves", () => {
+    vi.mocked(api.getAlmaOops).mockReturnValue(new Promise(() => {}) as any);
+    renderPage();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("renders failure cards with the occurrences badge from mocked data", async () => {
+    vi.mocked(api.getAlmaOops).mockResolvedValue({ env: "qa", windowDays: 10, items: [oopsItem] } as any);
+
+    renderPage();
+    expect(await screen.findByText("Oops_Test_1")).toBeInTheDocument();
+    expect(screen.getByText(/Occurred 5 times/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no rows", async () => {
+    vi.mocked(api.getAlmaOops).mockResolvedValue({ env: "qa", windowDays: 10, items: [] } as any);
+    renderPage();
+    expect(await screen.findByText(/No Alma oops failures/i)).toBeInTheDocument();
+  });
+
+  it("filters the cards by the search query", async () => {
+    const other = { ...oopsItem, testName: "Different_Test", area: "ERM" };
+    vi.mocked(api.getAlmaOops).mockResolvedValue({ env: "qa", windowDays: 10, items: [oopsItem, other] } as any);
+
+    renderPage();
+    expect(await screen.findByText("Oops_Test_1")).toBeInTheDocument();
+    expect(screen.getByText("Different_Test")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search/i), { target: { value: "Different" } });
+
+    expect(screen.queryByText("Oops_Test_1")).toBeNull();
+    expect(screen.getByText("Different_Test")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/__tests__/Recentfailurespage.test.tsx
+++ b/client/src/pages/__tests__/Recentfailurespage.test.tsx
@@ -36,7 +36,10 @@ describe("RecentFailuresPage", () => {
     vi.clearAllMocks();
     vi.mocked(api.getAreaTestRailIds).mockResolvedValue({ areaName: "LOD", env: "qa", baseUrl: "", ids: {} } as any);
     vi.mocked(api.getAreaRecentFailuresGrouped).mockResolvedValue({ area: "LOD", windowDays: 10, reasonsMax: 4, items: [groupedItem] } as any);
-    vi.mocked(api.getAreaLatestFailedTests).mockResolvedValue({ area: "LOD", env: "qa", totalCount: 0, servers: [] } as any);
+    vi.mocked(api.getAreaLatestFailedTests).mockResolvedValue({
+      area: "LOD", env: "qa", totalCount: 1,
+      servers: [{ server: "QAC01", tests: [{ testName: "Srv_Test", server: "QAC01", testedOn: null, failureText: "FATAL x", logLink: null, screenshotLink: null, almaVersion: null, buildNumber: null }] }],
+    } as any);
     vi.mocked(api.getAreaFailuresByReason).mockResolvedValue({
       area: "LOD", windowDays: 10, env: "qa",
       reasons: [{ reasonText: "FATAL shared reason", failCount: 2, tests: [groupedItem, { ...groupedItem, testName: "Other" }] }],
@@ -55,6 +58,13 @@ describe("RecentFailuresPage", () => {
   it("renders failure cards from mocked data on the All tab", async () => {
     renderPage();
     expect(await screen.findByText("MyFailingTest")).toBeInTheDocument();
+  });
+
+  it("loads the By Server tab with collapsed accordions by default", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "By Server" }));
+    const summary = await screen.findByRole("button", { name: /QAC01/i });
+    expect(summary).toHaveAttribute("aria-expanded", "false");
   });
 
   it("loads the By Reason tab with collapsed accordions by default", async () => {

--- a/client/src/services/apiService.ts
+++ b/client/src/services/apiService.ts
@@ -4,6 +4,7 @@ import type { AreaHealthResponse, EnvHealthResponse } from "../types/Health";
 import type { AreasDashboardResponse } from "../types/Dashboard";
 import type { AreaRecentFailuresGroupedResponse } from "../types/RecentFailuresGrouped";
 import type { AreaFailuresByReasonResponse } from "../types/FailuresByReason";
+import type { AlmaOopsResponse } from "../types/AlmaOops";
 import type { LatestFailedTestsResponse } from "../types/LatestFailed";
 import type { CommonFailuresResponse } from "../types/CommonFailures";
 import type { TestSearchResult } from "../types/TestSearch";
@@ -187,6 +188,14 @@ export const getAreaLatestFailedTests = async (
   const url = `${API_BASE_URL}/areas/${encodeURIComponent(areaName)}/latest-failed-tests?env=${env}`;
   const response = await fetch(url);
   return handleResponse<LatestFailedTestsResponse>(response);
+};
+
+export const getAlmaOops = async (
+  env: EnvFilter = "qa"
+): Promise<AlmaOopsResponse> => {
+  const url = `${API_BASE_URL}/alma-oops?env=${env}`;
+  const response = await fetch(url);
+  return handleResponse<AlmaOopsResponse>(response);
 };
 
 export const getCommonFailures = async (

--- a/client/src/types/AlmaOops.ts
+++ b/client/src/types/AlmaOops.ts
@@ -1,0 +1,14 @@
+import type { RecentFailureGroupedItem } from "./RecentFailuresGrouped";
+
+// Alma Oops items reuse the grouped-failure shape (so they render in FailureCard)
+// plus the originating area and an occurrences count.
+export type AlmaOopsItem = RecentFailureGroupedItem & {
+  area: string;
+  occurrences: number;
+};
+
+export type AlmaOopsResponse = {
+  env: string;
+  windowDays: number;
+  items: AlmaOopsItem[];
+};

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -7,16 +7,46 @@ This document defines the HTTP API contract between the React frontend and the N
 ## Base URLs
 
 - Health endpoint (not under `/api`): `http://localhost:5000/health`
-- API base (areas endpoints): `http://localhost:5000/api`
+- API base: `http://localhost:5000/api`
+
+The frontend (`client/src/services/apiService.ts`) calls the API via the relative base `"/api"`. In production the Express server also serves the built client (`client/dist`) and falls back to `index.html` for any non-`/api`, non-`/health` route.
 
 ---
 
 ## Conventions
 
 - All responses are JSON.
-- Date/time fields (e.g. `testedOn`) are returned as strings in the backend’s current format.
-- Area identifiers are case-sensitive in the API (examples use uppercase IDs such as `PRM`).
-- Errors use the JSON shape `{ "error": "<message>" }` when returned (see **Errors** section).
+- Date/time fields are returned as strings; format varies per endpoint (ISO-like `YYYY-MM-DDTHH:mm:ss`, `YYYY-MM-DD`, or a display string), noted where relevant.
+- Area identifiers are the values from `GET /api/areas` (examples use uppercase IDs such as `PRM`).
+- The `env` query param accepts `qa` | `release` | `sandbox`. Any other/missing value falls back to `qa`. It maps to a server-name filter (`buildServerFilter`).
+- `daysBack` and `windowDays` are interchangeable on endpoints that accept a lookback window; each endpoint clamps to its own maximum.
+- Errors use the JSON shape `{ "error": "<message>" }` (see **Errors** section).
+
+---
+
+## Endpoint Summary
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| GET | `/health` | Backend availability |
+| GET | `/api/areas` | List dashboard areas (dynamic, DB-backed) |
+| GET | `/api/areas/dashboard` | Per-area totals + health buckets for all areas |
+| GET | `/api/areas/daily-trends` | Daily pass/fail trends for all areas |
+| GET | `/api/areas/{areaName}/summary` | Single-area aggregated summary |
+| GET | `/api/areas/{areaName}/health` | Daily health time-series for an area |
+| GET | `/api/areas/{areaName}/failures` | Raw failure rows for an area |
+| GET | `/api/areas/{areaName}/recent-failures-grouped` | Recent failures grouped by test name |
+| GET | `/api/areas/{areaName}/health-tests` | Tests in a given health bucket |
+| GET | `/api/areas/{areaName}/daily-trend` | Daily pass/fail trend for one area |
+| GET | `/api/areas/{areaName}/latest-failed-tests` | Latest failed tests grouped by server |
+| GET | `/api/areas/{areaName}/tests/{testName}/history` | Per-test run history |
+| GET | `/api/areas/{areaName}/testrail-ids` | TestRail case IDs for an area's tests |
+| GET | `/api/areas/{areaName}/failures-by-reason` | Failures grouped by reason text |
+| GET | `/api/envs/{env}/health` | Daily health time-series for an environment |
+| GET | `/api/common-failures` | Cross-area failure clusters |
+| GET | `/api/alma-oops` | Legacy "Alma oops" failures (FATAL + "Message appear") |
+| GET | `/api/logs/expand` | Parsed/expanded Jenkins log snippet |
+| GET | `/api/test-results` | Test name search (and raw rows when no query) |
 
 ---
 
@@ -32,7 +62,7 @@ Returns backend availability information.
   "status": "OK",
   "system": "Automation Dashboard Backend"
 }
-````
+```
 
 ---
 
@@ -40,76 +70,87 @@ Returns backend availability information.
 
 ### GET `/api/areas`
 
-Returns the list of dashboard areas.
+Returns the list of dashboard areas. Resolved dynamically from the database (`SELECT DISTINCT` areas with display-name overrides, cached for 24h). On a DB error the server falls back to the static config in `config/areas.ts`.
 
 **Response — 200 OK**
-
 ```json
 [
   { "id": "PRM", "name": "PRM" },
-  { "id": "PRM_OLD", "name": "PRM (old)" },
   { "id": "ERM", "name": "ERM" },
-  { "id": "ALMAE", "name": "Alma Starter" },
-  { "id": "AUTHORITY", "name": "Authorities" },
-  { "id": "ANALYTICS", "name": "Analytics" },
-  { "id": "API", "name": "API" },
-  { "id": "ACQ", "name": "Acquisition" },
-  { "id": "FULF_OLD", "name": "Fulfillment (old)" },
-  { "id": "FULF", "name": "Fulfillment" },
-  { "id": "RSH", "name": "Resource Sharing" },
-  { "id": "INTEROPERABILITY", "name": "Interoperability" },
-  { "id": "INTEROPERABILITYNG", "name": "InteroperabilityNG" },
-  { "id": "USERS", "name": "Users" },
-  { "id": "LOD", "name": "Linked open data" },
-  { "id": "NMDEDITOR", "name": "NMDEditor" },
-  { "id": "METADATAMANAGEMENT", "name": "Metadata Management" },
-  { "id": "RMANDCONSORTIA", "name": "RM and Consortia" },
-  { "id": "STAFFSEARCH", "name": "StaffSearch" },
-  { "id": "PUBLISHING", "name": "Publishing" },
-  { "id": "GLOBALRS", "name": "Rapido" },
-  { "id": "COLLECTO", "name": "Collecto" },
-  { "id": "SPECTO", "name": "Specto" },
-  { "id": "SPECTOESSENTIAL", "name": "Specto Essential" },
-  { "id": "SPECTOPRESERVATION", "name": "Specto Preservation" }
+  { "id": "ANALYTICS", "name": "Analytics" }
 ]
 ```
 
 **Notes**
-
-* `id` is the value used by the frontend in URLs (e.g. `/api/areas/{id}/summary`).
-* `name` is the display label shown in the UI.
+- `id` is the value used by the frontend in URLs (e.g. `/api/areas/{id}/summary`).
+- `name` is the display label shown in the UI.
 
 ---
 
-## Area Summary
+### GET `/api/areas/dashboard`
 
-### GET `/api/areas/{areaId}/summary`
-
-Returns an aggregated summary for a specific area.
-
-**Path params**
-
-* `areaId` (string) — the area identifier from `GET /api/areas` (example: `PRM`).
+Per-area totals and health buckets for all areas (powers the dashboard grid).
 
 **Query params**
-
-* `limit` (number, default: `10`) — number of failure items to return in `recentFailures`.
-* `daysBack` (number, default: `7`) — planned lookback window.
-
-  * **Current implementation note:** the backend currently summarizes the *latest run day* (based on `MAX(TRUNC(TESTEDON))`). `daysBack` is parsed but not applied in the SQL yet.
+- `daysBack` (number, default `8`, must be `> 0`) — lookback window.
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
 
 **Response — 200 OK**
+```json
+{
+  "daysBack": 8,
+  "items": [
+    {
+      "area": "PRM",
+      "last": { "passed": 99, "failed": 21, "total": 120, "passRate": 82.5 },
+      "health": { "healthy": 40, "medium": 5, "bad": 3, "dead": 2 }
+    }
+  ]
+}
+```
 
+---
+
+### GET `/api/areas/daily-trends`
+
+Daily pass/fail/total counts for every area, keyed by area name.
+
+**Query params**
+- `daysBack` (number, default `8`, must be `> 0`, max `90`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "env": "qa",
+  "daysBack": 8,
+  "areas": {
+    "PRM": [
+      { "date": "2026-06-18", "passed": 99, "failed": 21, "total": 120 }
+    ]
+  }
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/summary`
+
+Aggregated summary for a single area.
+
+**Path params**
+- `areaName` (string) — area identifier from `GET /api/areas`.
+
+**Query params**
+- `limit` (number, default `10`, must be `> 0`) — number of items in `recentFailures`.
+- `daysBack` (number, default `7`, must be `> 0`) — parsed/validated but not currently applied in the SQL (summary uses the latest run day).
+
+**Response — 200 OK**
 ```json
 {
   "area": "PRM",
   "windowDays": 1,
-  "totals": {
-    "passed": 99,
-    "failed": 120,
-    "total": 222,
-    "passRate": 44.59
-  },
+  "totals": { "passed": 99, "failed": 120, "total": 222, "passRate": 44.59 },
   "lastRun": {
     "testedOn": "01/02/2026 00:00",
     "buildNumber": 0,
@@ -133,93 +174,502 @@ Returns an aggregated summary for a specific area.
 
 ---
 
+### GET `/api/areas/{areaName}/health`
+
+Daily health time-series for an area.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `daysBack` (number, default `8`, must be `> 0`).
+
+**Response — 200 OK**
+```json
+{
+  "area": "PRM",
+  "windowDays": 8,
+  "series": [
+    { "runDay": "2026-06-18", "passed": 99, "failed": 21, "skipped": 0, "total": 120, "passRate": 82.5 }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/failures`
+
+Raw failure rows for an area.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `daysBack` (number, default `7`, clamped to max `90`).
+- `limit` (number, default `50`, clamped to max `500`).
+- `latestPerTest` (boolean-ish: `1|true|yes|y|on`, default `false`) — when true, only each test's latest failure.
+
+**Response — 200 OK** — array of failure rows for the area (server-shaped failure objects).
+
+---
+
+### GET `/api/areas/{areaName}/recent-failures-grouped`
+
+Recent failures grouped by test name (one card per test, with its distinct reasons).
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `windowDays` (alias `daysBack`, default `7`, clamped to max `90`).
+- `limit` (number, default `50`, clamped to max `500`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "area": "PRM",
+  "windowDays": 10,
+  "reasonsMax": 3,
+  "items": [
+    {
+      "testName": "SynchAndEdit...",
+      "failCount": 4,
+      "lastFailedOn": "2026-06-18",
+      "jobName": "PRM_QA_NIGHTLY",
+      "reasons": [
+        { "text": "FATAL ...", "lastDate": "2026-06-18", "screenshotLink": "http://...", "logLink": "http://..." }
+      ],
+      "lastFailure": {
+        "server": "SQA02_NA03",
+        "almaVersion": "April2026",
+        "buildNumber": 0,
+        "logLink": "http://...",
+        "screenshotLink": "http://..."
+      }
+    }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/health-tests`
+
+Tests belonging to a given health bucket.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `bucket` (required, one of `healthy` | `medium` | `bad` | `dead`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+- `daysBack` (number, default `8`, must be `> 0`).
+
+**Response — 200 OK**
+```json
+{
+  "areaName": "PRM",
+  "bucket": "bad",
+  "env": "qa",
+  "tests": [
+    {
+      "testName": "SynchAndEdit...",
+      "passRate": 12.5,
+      "successes": 1,
+      "fails": 7,
+      "lastRunDate": "2026-06-18",
+      "lastPassed": false,
+      "lastSuccess": "2026-06-10",
+      "lastFailure": "2026-06-18"
+    }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/daily-trend`
+
+Daily pass/fail trend for a single area.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `daysBack` (number, default `8`, must be `> 0`, clamped to max `30`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "areaName": "PRM",
+  "env": "qa",
+  "daysBack": 8,
+  "points": [
+    { "date": "2026-06-18", "passed": 99, "failed": 21, "total": 120 }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/latest-failed-tests`
+
+Latest failed test per test name, grouped by server.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "area": "PRM",
+  "env": "qa",
+  "totalCount": 12,
+  "servers": [
+    {
+      "server": "SQA02_NA03",
+      "tests": [
+        {
+          "testName": "SynchAndEdit...",
+          "server": "SQA02_NA03",
+          "testedOn": "2026-06-18",
+          "failureText": "FATAL ...",
+          "logLink": "http://...",
+          "screenshotLink": "http://...",
+          "almaVersion": "April2026",
+          "buildNumber": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/tests/{testName}/history`
+
+Run history for a single test.
+
+**Path params**
+- `areaName` (string).
+- `testName` (string).
+
+**Query params**
+- `daysBack` (alias `windowDays`, number, default `30`, must be `> 0`, clamped to max `365`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "area": "PRM",
+  "testName": "SynchAndEdit...",
+  "env": "qa",
+  "rows": [
+    {
+      "testedOn": "2026-06-18T00:00:00",
+      "endingTimeUnix": 1750204800000,
+      "passed": false,
+      "server": "SQA02_NA03",
+      "buildNumber": 0,
+      "almaVersion": "April2026",
+      "failureText": "FATAL ...",
+      "logLink": "http://...",
+      "screenshotLink": "http://..."
+    }
+  ]
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/testrail-ids`
+
+TestRail case IDs mapped per test name, plus the TestRail base URL for building deep links.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "areaName": "PRM",
+  "env": "qa",
+  "baseUrl": "https://exlibris.testrail.com/index.php?/cases/view/",
+  "ids": { "SynchAndEdit...": "123456" }
+}
+```
+
+---
+
+### GET `/api/areas/{areaName}/failures-by-reason`
+
+Failures grouped by their reason text (the "By Reason" view). Each reason groups the affected tests.
+
+**Path params**
+- `areaName` (string).
+
+**Query params**
+- `windowDays` (alias `daysBack`, number, default `10`, must be `> 0`, clamped to max `90`).
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "area": "PRM",
+  "windowDays": 10,
+  "env": "qa",
+  "reasons": [
+    {
+      "reasonText": "FATAL ...",
+      "failCount": 5,
+      "tests": [
+        {
+          "testName": "SynchAndEdit...",
+          "failCount": 3,
+          "lastFailedOn": "2026-06-18",
+          "jobName": "PRM_QA_NIGHTLY",
+          "reasons": [
+            { "text": "FATAL ...", "lastDate": "2026-06-18", "screenshotLink": "http://...", "logLink": "http://..." }
+          ],
+          "lastFailure": {
+            "server": "SQA02_NA03",
+            "almaVersion": "April2026",
+            "buildNumber": 0,
+            "logLink": "http://...",
+            "screenshotLink": "http://..."
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Environments
+
+### GET `/api/envs/{env}/health`
+
+Daily health time-series for an environment.
+
+**Path params**
+- `env` (string) — must match `^[A-Za-z0-9_-]+$`.
+
+**Query params**
+- `daysBack` (number, default `8`, must be `> 0`).
+
+**Response — 200 OK**
+```json
+{
+  "env": "qa",
+  "windowDays": 8,
+  "series": [
+    { "runDay": "2026-06-18", "passed": 990, "failed": 210, "skipped": 0, "total": 1200, "passRate": 82.5 }
+  ]
+}
+```
+
+---
+
+## Common Failures
+
+### GET `/api/common-failures`
+
+Failure clusters shared across multiple areas (same failure text seen in more than one place).
+
+**Query params**
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "env": "qa",
+  "clusters": [
+    {
+      "failureText": "FATAL ...",
+      "occurrenceCount": 12,
+      "affectedAreas": ["PRM", "ERM"],
+      "examples": [
+        { "area": "PRM", "testName": "SynchAndEdit...", "logLink": "http://...", "screenshotLink": "http://..." }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Alma oops
+
+### GET `/api/alma-oops`
+
+Legacy "Alma oops" failures, reproducing the old dashboard's logic exactly:
+
+- **Fixed 10-day window** (`TESTEDON >= SYSDATE - 10`).
+- Each test is evaluated on its **latest run only** (`ROW_NUMBER() PARTITION BY UPPER(TESTNAME) ORDER BY TESTEDON DESC, ENDINGTIMEUNIX DESC`).
+- A test qualifies only if that **latest run's** `FAILURETEXT` contains both `FATAL` **and** `Message appear` (case-sensitive `LIKE`), exactly matching the legacy `String.contains` checks. Tests whose latest run passed (or otherwise doesn't match) are excluded.
+- Server scoped by the `env` filter.
+- On top of the legacy set: results are aggregated with `GROUP BY AREA, TESTNAME` and a `COUNT(*)` **occurrences** count (how many matching runs each test had in the window), avoiding duplicate rows.
+
+**Query params**
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK**
+```json
+{
+  "env": "qa",
+  "windowDays": 10,
+  "items": [
+    {
+      "area": "PRM",
+      "testName": "SynchAndEdit...",
+      "occurrences": 4,
+      "failCount": 4,
+      "lastFailedOn": "2026-06-18",
+      "jobName": "PRM_QA_NIGHTLY",
+      "reasons": [
+        { "text": "FATAL ... Message appear ...", "lastDate": "2026-06-18", "screenshotLink": "http://...", "logLink": "http://..." }
+      ],
+      "lastFailure": {
+        "server": "SQA02_NA03",
+        "almaVersion": "April2026",
+        "buildNumber": 0,
+        "logLink": "http://...",
+        "screenshotLink": "http://..."
+      }
+    }
+  ]
+}
+```
+
+**Notes**
+- `failCount` mirrors `occurrences` so the shared `FailureCard` badge renders correctly.
+- `windowDays` is always `10` (fixed).
+
+---
+
+## Logs
+
+### GET `/api/logs/expand`
+
+Fetches a Jenkins log and returns a parsed snippet around the failure (first `FATAL`, searching back to the test name, falling back to the last lines). Results are cached in-memory. Sensitive values are redacted.
+
+**Query params**
+- `logUrl` (string, **required**) — the Jenkins log URL.
+- `testName` (string, optional) — used to anchor the parsed window.
+
+**Response — 200 OK (parsed/fallback)**
+```json
+{
+  "available": true,
+  "lines": ["...log line...", "...FATAL..."],
+  "source": "parsed"
+}
+```
+`source` is `"parsed"` or `"fallback"`.
+
+**Response — 200 OK (unavailable)**
+```json
+{
+  "available": false,
+  "error": "Log file is no longer available on Jenkins. Please use the Full Log link."
+}
+```
+
+**Response — 400 Bad Request** — missing `logUrl`
+```json
+{ "available": false, "error": "Missing logUrl" }
+```
+
+---
+
+## Test Results / Search
+
+### GET `/api/test-results`
+
+Searches test names (when `q` is provided) or returns raw rows.
+
+**Query params**
+- `q` (string, optional) — test-name search term. When present, returns the latest run per matching `(area, testName)`.
+- `limit` (number, default `10`, clamped to max `25`) — only applies to search results.
+- `env` (`qa` | `release` | `sandbox`, default `qa`).
+
+**Response — 200 OK (with `q`)**
+```json
+[
+  { "area": "PRM", "testName": "SynchAndEdit...", "testedOn": "2026-06-18T00:00:00" }
+]
+```
+
+**Response — 200 OK (no `q`)** — up to 50 raw `QA_AUTOMATION.TESTRESULTS` rows (Oracle column shape).
+
+---
+
 ## Response shape definitions
 
-### `totals`
+### `totals` / `last` (DashboardTotals)
+- `passed` (number)
+- `failed` (number)
+- `total` (number)
+- `passRate` (number) — pass percentage (0–100).
 
-* `passed` (number) — count of passed tests in the selected summary scope.
-* `failed` (number) — count of failed tests in the selected summary scope.
-* `total` (number) — total tests in the selected summary scope.
-* `passRate` (number) — pass percentage (0–100).
+### `health` (HealthBuckets)
+- `healthy` / `medium` / `bad` / `dead` (number) — count of tests in each bucket.
+- Bucketing thresholds: `≥80%` healthy, `20–79%` medium, `1–19%` bad, `0 tests` dead.
 
-### `lastRun`
+### Health series point
+- `runDay` (string `YYYY-MM-DD`)
+- `passed` / `failed` / `skipped` / `total` (number)
+- `passRate` (number)
 
-* `testedOn` (string | null) — date/time of the last run day (format as returned by backend).
-* `buildNumber` (number | null)
-* `server` (string | null)
-* `almaVersion` (string | null)
+### Daily trend point
+- `date` (string `YYYY-MM-DD`)
+- `passed` / `failed` / `total` (number)
 
-### `recentFailures[]`
-
-Each item includes:
-
-* `testedOn` (string | null)
-* `testName` (string | null)
-* `server` (string | null)
-* `almaVersion` (string | null)
-* `buildNumber` (number | null)
-* `logLink` (string | null)
-* `screenshotLink` (string | null)
-* `failureTextPreview` (string | null) — short failure preview (may include escaped HTML).
+### Grouped failure item (`recent-failures-grouped`, `failures-by-reason`, `alma-oops`)
+- `testName` (string)
+- `failCount` (number)
+- `lastFailedOn` (string | null)
+- `jobName` (string | null, optional) — Jenkins job extracted from the log/screenshot URL.
+- `reasons[]` — `{ text, lastDate, screenshotLink, logLink }`
+- `lastFailure` — `{ server, almaVersion, buildNumber, logLink, screenshotLink }`
 
 ---
 
 ## Errors
 
-### Current behavior
-
-* Unknown `areaId` returns `200 OK` with an empty summary object:
-
-  * `totals` values are all `0`
-  * `lastRun` fields are `null`
-  * `recentFailures` is an empty array
-
-Example (unknown area):
-
-```json
-{
-  "area": "NOT_EXIST",
-  "windowDays": 1,
-  "totals": {
-    "passed": 0,
-    "failed": 0,
-    "total": 0,
-    "passRate": 0
-  },
-  "lastRun": {
-    "testedOn": null,
-    "buildNumber": null,
-    "server": null,
-    "almaVersion": null
-  },
-  "recentFailures": []
-}
-```
-
-### Recommended standard (planned)
-
-The backend should return errors in this format:
+### Standard error shape
 
 ```json
 { "error": "Human readable message" }
 ```
 
-Examples:
+### By status code
 
-* `404 Not Found` — unknown `areaId`
+- **`400 Bad Request`** — invalid query/path params. Examples:
+  - `{ "error": "daysBack must be a positive number" }`
+  - `{ "error": "limit must be a positive number" }`
+  - `{ "error": "bucket must be one of: healthy, medium, bad, dead" }`
+  - `{ "error": "daysBack must not exceed 90" }`
+  - `{ "error": "env contains invalid characters" }`
+  - `{ "available": false, "error": "Missing logUrl" }` (logs endpoint)
 
-```json
-{ "error": "Unknown areaId: NOT_EXIST" }
-```
+- **`404 Not Found`** — unknown area on area-scoped endpoints (validated via dynamic `isKnownArea`):
+  - `{ "error": "Unknown areaId: NOT_EXIST" }`
 
-* `400 Bad Request` — invalid query params (e.g., negative or non-numeric `limit`)
+- **`500 Internal Server Error`** — database connection or query failure:
+  - `{ "error": "Internal Server Error" }`
+  - `{ "error": "Failed to fetch test results" }` (test-results endpoint)
+  - `{ "available": false, "error": "Failed to parse log." }` (logs endpoint)
 
-```json
-{ "error": "limit must be a positive number" }
-```
-
-* `500 Internal Server Error` — database connection or query failure
-
-```json
-{ "error": "Internal Server Error" }
-```
+**Note:** `GET /api/areas/{areaName}/summary` does not 404 via `isKnownArea` for genuinely empty areas the same way — an unknown area returns `404`, but an area with no data in the window returns a zero-filled summary.

--- a/server/src/controllers/almaOopsController.ts
+++ b/server/src/controllers/almaOopsController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from "express";
+import { getAlmaOops } from "../services/almaOopsService";
+import { EnvFilter } from "../services/envFilter";
+
+export const getAlmaOopsHandler = async (req: Request, res: Response) => {
+  try {
+    const envRaw = (req.query.env as string | undefined)?.toLowerCase();
+    const env: EnvFilter = envRaw === "release" ? "release" : envRaw === "sandbox" ? "sandbox" : "qa";
+
+    const data = await getAlmaOops(env);
+    return res.json(data);
+  } catch (error) {
+    console.error("Error fetching Alma OOPS:", error);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import areasRoutes from "./routes/areasRoutes";
 import envsRoutes from "./routes/envsRoutes";
 import commonRoutes from "./routes/commonRoutes";
 import logsRoutes from "./routes/logsRoutes";
+import almaOopsRoutes from "./routes/almaOopsRoutes";
 import { checkConnection, closePool } from "./db";
 
 dotenv.config();
@@ -22,6 +23,7 @@ app.use("/api/areas", areasRoutes);
 app.use("/api/envs", envsRoutes);
 app.use("/api/common-failures", commonRoutes);
 app.use("/api/logs", logsRoutes);
+app.use("/api/alma-oops", almaOopsRoutes);
 
 app.get("/health", (req: Request, res: Response) => {
   res.json({ status: "OK", system: "Automation Dashboard Backend" });

--- a/server/src/routes/almaOopsRoutes.ts
+++ b/server/src/routes/almaOopsRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getAlmaOopsHandler } from "../controllers/almaOopsController";
+
+const router = Router();
+
+router.get("/", getAlmaOopsHandler);
+
+export default router;

--- a/server/src/services/almaOopsService.ts
+++ b/server/src/services/almaOopsService.ts
@@ -1,0 +1,136 @@
+import { execute } from "../db";
+import { cleanReason } from "../utils/failureText";
+import { jobNameFromLinks } from "../utils/jobName";
+import { EnvFilter, buildServerFilter } from "./envFilter";
+
+export type { EnvFilter };
+
+// Fixed 10-day window for Alma Oops (legacy "Alma oops").
+const WINDOW_DAYS = 10;
+
+// Strict legacy "Alma oops" logic (from old dashboard's getresult/getTestFailure):
+//  - take only each test's LATEST run (ORDER BY testedon DESC, endingTimeUnix DESC),
+//  - that latest run's FAILURETEXT must contain "FATAL" AND "Message appear"
+//    (case-sensitive, exactly as the legacy String.contains checks),
+//  - server scoped by the env filter (legacy filterServer).
+// On top of that legacy set we add: the 10-day window and a COUNT(*) occurrences
+// aggregation (how many matching runs each test had) to avoid duplicate rows.
+function buildSQL(serverFilter: string): string {
+  return `
+WITH base AS (
+  SELECT
+    AREA,
+    TESTNAME,
+    UPPER(TESTNAME) AS TKEY,
+    PASSED,
+    TESTEDON,
+    ENDINGTIMEUNIX,
+    SERVER,
+    ALMAVERSION,
+    BUILDNUMBER,
+    LOGLINK,
+    SCREENSHOTLINK,
+    FAILURETEXT
+  FROM QA_AUTOMATION.TESTRESULTS
+  WHERE TESTEDON >= SYSDATE - 10
+    ${serverFilter}
+),
+ranked AS (
+  SELECT base.*, ROW_NUMBER() OVER (
+    PARTITION BY TKEY ORDER BY TESTEDON DESC, NVL(ENDINGTIMEUNIX, 0) DESC
+  ) AS RN
+  FROM base
+),
+oops_latest AS (
+  -- Legacy membership: a test is an "Alma oops" iff its LATEST run matches.
+  SELECT TKEY
+  FROM ranked
+  WHERE RN = 1
+    AND FAILURETEXT LIKE '%FATAL%'
+    AND FAILURETEXT LIKE '%Message appear%'
+),
+matching AS (
+  SELECT b.*
+  FROM base b
+  JOIN oops_latest o ON o.TKEY = b.TKEY
+  WHERE b.FAILURETEXT LIKE '%FATAL%'
+    AND b.FAILURETEXT LIKE '%Message appear%'
+)
+SELECT
+  AREA,
+  TESTNAME,
+  COUNT(*)                                                                  AS OCCURRENCES,
+  MAX(ENDINGTIMEUNIX)                                                       AS LAST_ENDING_UNIX,
+  MAX(TESTEDON)                                                             AS LAST_TESTEDON,
+  MAX(SERVER)         KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS SERVER,
+  MAX(ALMAVERSION)    KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS ALMAVERSION,
+  MAX(BUILDNUMBER)    KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS BUILDNUMBER,
+  MAX(LOGLINK)        KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS LOGLINK,
+  MAX(SCREENSHOTLINK) KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS SCREENSHOTLINK,
+  MAX(FAILURETEXT)    KEEP (DENSE_RANK LAST ORDER BY ENDINGTIMEUNIX)        AS FAILURETEXT
+FROM matching
+GROUP BY AREA, TESTNAME
+ORDER BY OCCURRENCES DESC, LAST_ENDING_UNIX DESC NULLS LAST
+`;
+}
+
+function formatUnixMs(x: unknown): string | null {
+  const n = typeof x === "number" ? x : Number(x);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const d = new Date(n);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+function formatDate(x: unknown): string | null {
+  if (!x) return null;
+  const d = x instanceof Date ? x : new Date(x as any);
+  if (isNaN(d.getTime())) return null;
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+function toNumber(x: unknown): number | null {
+  if (typeof x === "number") return x;
+  const n = Number(x);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function getAlmaOops(env: EnvFilter = "qa") {
+  const serverFilter = buildServerFilter(env);
+  const sql = buildSQL(serverFilter);
+
+  const res = await execute(sql, {});
+  const rows = (res.rows ?? []) as any[];
+
+  const items = rows.map((r) => {
+    const logLink = (r.LOGLINK ?? null) as string | null;
+    const screenshotLink = (r.SCREENSHOTLINK ?? null) as string | null;
+    const occurrences = Number(r.OCCURRENCES ?? 0);
+    const fullReason = cleanReason(r.FAILURETEXT);
+
+    return {
+      area: String(r.AREA ?? ""),
+      testName: String(r.TESTNAME ?? ""),
+      occurrences,
+      // failCount mirrors occurrences so the shared FailureCard badge reads correctly.
+      failCount: occurrences,
+      lastFailedOn: formatUnixMs(r.LAST_ENDING_UNIX),
+      jobName: jobNameFromLinks(logLink, screenshotLink),
+      reasons: fullReason
+        ? [{ text: fullReason, lastDate: formatDate(r.LAST_TESTEDON), screenshotLink, logLink }]
+        : [],
+      lastFailure: {
+        server: (r.SERVER ?? null) as string | null,
+        almaVersion: (r.ALMAVERSION ?? null) as string | null,
+        buildNumber: toNumber(r.BUILDNUMBER),
+        logLink,
+        screenshotLink,
+      },
+    };
+  });
+
+  return { env, windowDays: WINDOW_DAYS, items };
+}

--- a/server/src/tests/almaOopsController.test.ts
+++ b/server/src/tests/almaOopsController.test.ts
@@ -1,0 +1,38 @@
+jest.mock("../services/almaOopsService", () => ({ getAlmaOops: jest.fn() }));
+
+import { Request, Response } from "express";
+import { getAlmaOops } from "../services/almaOopsService";
+import { getAlmaOopsHandler } from "../controllers/almaOopsController";
+
+const mockGet = getAlmaOops as jest.Mock;
+
+function mockRes() {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe("getAlmaOopsHandler", () => {
+  it("returns 200 with the data", async () => {
+    mockGet.mockResolvedValue({ env: "qa", windowDays: 10, items: [] });
+    const req = { query: { env: "qa" } } as unknown as Request;
+    const res = mockRes();
+
+    await getAlmaOopsHandler(req, res);
+
+    expect(mockGet).toHaveBeenCalledWith("qa");
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ items: [] }));
+  });
+
+  it("returns 500 when the service throws", async () => {
+    mockGet.mockRejectedValue(new Error("boom"));
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    const req = { query: {} } as unknown as Request;
+    const res = mockRes();
+
+    await getAlmaOopsHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/server/src/tests/almaOopsService.test.ts
+++ b/server/src/tests/almaOopsService.test.ts
@@ -1,0 +1,60 @@
+jest.mock("../db", () => ({ execute: jest.fn() }));
+
+import { execute } from "../db";
+import { getAlmaOops } from "../services/almaOopsService";
+
+const mockExecute = execute as jest.Mock;
+
+describe("almaOopsService.getAlmaOops", () => {
+  it("maps aggregated rows and exposes the occurrences count", async () => {
+    mockExecute.mockResolvedValue({
+      rows: [
+        {
+          AREA: "LOD",
+          TESTNAME: "MyTest",
+          OCCURRENCES: 5,
+          LAST_ENDING_UNIX: 1000,
+          LAST_TESTEDON: null,
+          SERVER: "QAC01",
+          ALMAVERSION: "v1",
+          BUILDNUMBER: 3,
+          LOGLINK: "http://log",
+          SCREENSHOTLINK: null,
+          FAILURETEXT: "FATAL Message appear popup",
+        },
+      ],
+    });
+
+    const result = await getAlmaOops("qa");
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      area: "LOD",
+      testName: "MyTest",
+      occurrences: 5,
+      failCount: 5, // mirrors occurrences for the shared FailureCard badge
+    });
+    expect(result.windowDays).toBe(10);
+  });
+
+  it("applies the strict legacy filters plus the 10-day limit and aggregation", async () => {
+    mockExecute.mockResolvedValue({ rows: [] });
+    await getAlmaOops("qa");
+
+    const sql = mockExecute.mock.calls[0][0] as string;
+    // 10-day window + aggregation
+    expect(sql).toMatch(/SYSDATE\s*-\s*10/);
+    expect(sql).toMatch(/COUNT\(\*\)\s+AS\s+OCCURRENCES/i);
+    expect(sql).toMatch(/GROUP BY/i);
+    // strict legacy: latest-run-only membership + case-sensitive FATAL + Message appear
+    expect(sql).toMatch(/ROW_NUMBER\(\)\s+OVER/i);
+    expect(sql).toContain("LIKE '%FATAL%'");
+    expect(sql).toContain("LIKE '%Message appear%'");
+  });
+
+  it("returns an empty list when there are no rows", async () => {
+    mockExecute.mockResolvedValue({ rows: [] });
+    const result = await getAlmaOops("release");
+    expect(result.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
This pull request introduces several new features and improvements to the client application, most notably adding a new "Alma Oops" page, implementing a reusable persistent search history component, and updating the way failures are displayed by reason. It also includes comprehensive tests for the new components and hooks. The changes enhance user experience by making navigation and search more intuitive and consistent across the app.

**New "Alma Oops" Page:**

- Added a new route and page (`AlmaOopsPage`) that displays "Message appear" popup failures from the last 10 days, with environment selection, search/filtering, and navigation back to the dashboard. The page shows failure cards with occurrence badges and handles loading, error, and empty states. [[1]](diffhunk://#diff-806f832717d34892b2c71aee7479df8973c5648bfdfa9da11ae30d462f5f8f1fR1-R154) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R7) [[3]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R20) [[4]](diffhunk://#diff-56d97a6e39af6739675f9652b64c19ba91e0e93f50949b7d4b7a660d7326c3ebR1-R21)

**Persistent Search History:**

- Introduced a reusable `SearchWithHistory` component that provides a search input with a dropdown of recent search terms, supporting localStorage persistence, de-duplication, and removal. [[1]](diffhunk://#diff-c566db16bdda6e1767e7f385fc276aeeffab17f7dd92ed945b1c7cc23a57ed84R1-R113) [[2]](diffhunk://#diff-713464492f841f87ac37a3e8ac64931d892d559329a718ee16af3d4f8d8e08b3R1-R50)
- Added a custom `useSearchHistory` hook to manage search history state, including synchronization across components and browser tabs, with tests for all behaviors. [[1]](diffhunk://#diff-c49b7f00f21e44d35f7954bc8c810ab543f103d86e1f8a0425e91765141ac23cR1-R70) [[2]](diffhunk://#diff-96a22330ea600d27a7db44cf95cf4bab7c8b529990cc0ce279e43549cdb44487R1-R55)
- Updated the dashboard to use the new `SearchWithHistory` component for area search, and to persist recent dashboard searches. [[1]](diffhunk://#diff-63f9e0eae72c59246c11b80522da420920080bf46a6f207aff383cdb0dbc0f87L20-R26) [[2]](diffhunk://#diff-63f9e0eae72c59246c11b80522da420920080bf46a6f207aff383cdb0dbc0f87R55)

**Failure Display Improvements:**

- Refactored the "By Reason" view to use a compact `FailureRowList` layout (consistent with other tabs), replacing the previous card-based layout for grouped failures. [[1]](diffhunk://#diff-bc667acd00f52e63e5c7b440087d35f077a412df7d68f222ff46c3fdcc5f0bcfL4-R4) [[2]](diffhunk://#diff-bc667acd00f52e63e5c7b440087d35f077a412df7d68f222ff46c3fdcc5f0bcfL60-L74)

**Testing and Quality:**

- Added end-to-end tests to verify navigation to the new Alma Oops page works and that the page settles into a valid state.
- Comprehensive unit tests for the new search history hook and component, ensuring correct persistence, de-duplication, and UI behavior. [[1]](diffhunk://#diff-713464492f841f87ac37a3e8ac64931d892d559329a718ee16af3d4f8d8e08b3R1-R50) [[2]](diffhunk://#diff-96a22330ea600d27a7db44cf95cf4bab7c8b529990cc0ce279e43549cdb44487R1-R55)

These changes collectively improve the discoverability, consistency, and usability of searching and navigating failure data in the app.