### PR TITLE
Notes

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+# Base URL used to turn JIRA ticket IDs (e.g. URM-88888) in notes into clickable links.
+# The detected ticket ID is appended to this value.
+VITE_JIRA_BASE_URL=https://your-company.atlassian.net/browse/

--- a/client/src/components/AreaCard.tsx
+++ b/client/src/components/AreaCard.tsx
@@ -50,9 +50,17 @@ const AreaCard: React.FC<AreaCardProps> = ({
 
   const trendData = (trendDataProp && trendDataProp.length > 0) ? trendDataProp : fetchedTrend;
 
+  // Show the EXACT pass rate of the latest day — matching the right-most plotted
+  // point in the trend chart (same ascending-date sort + rounding it uses).
+  const sortedTrend = [...trendData].sort((a, b) => a.date.localeCompare(b.date));
+  const latestDay = [...sortedTrend].reverse().find((p) => p.total > 0) ?? null;
+  const displayRate = latestDay
+    ? Math.round((latestDay.passed / latestDay.total) * 100)
+    : passRate;
+
   let statusColor = '#d32f2f';
-  if (passRate > 80) statusColor = '#2e7d32';
-  else if (passRate > 50) statusColor = '#ed6c02';
+  if (displayRate > 80) statusColor = '#2e7d32';
+  else if (displayRate > 50) statusColor = '#ed6c02';
 
   return (
     <Card
@@ -84,7 +92,7 @@ const AreaCard: React.FC<AreaCardProps> = ({
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Typography variant="h3" sx={{ color: statusColor, fontWeight: 'bold' }}>
-            {passRate}%
+            {displayRate}%
           </Typography>
 
           <Box textAlign="right">

--- a/client/src/components/ByReasonView.tsx
+++ b/client/src/components/ByReasonView.tsx
@@ -59,7 +59,7 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             </Typography>
             {/* Collapsed: read-only reason note chips, flush right before the count + arrow. */}
             {!isExpanded && (
-              <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "40%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+              <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "40%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                 <InlineNotes scope="reason" entityId={`reason:${areaName ?? ""}:${idx}`} readOnly />
               </Box>
             )}

--- a/client/src/components/ByReasonView.tsx
+++ b/client/src/components/ByReasonView.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Typography, Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import FailureRowList from "./FailureRowList";
+import InlineNotes from "./InlineNotes";
 import type { ReasonGroup } from "../types/FailuresByReason";
 
 interface ByReasonViewProps {
@@ -18,15 +19,22 @@ function previewReason(text: string): string {
   return line.length > 160 ? `${line.slice(0, 160)}…` : line;
 }
 
+
 const ByReasonView: React.FC<ByReasonViewProps> = ({
   reasons, areaName, onImageClick, onExpandLog, onOpenHistory, testRailUrlFor,
 }) => {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {reasons.map((group, idx) => (
+      {reasons.map((group, idx) => {
+        const isExpanded = expandedIdx === idx;
+        return (
         <Accordion
           key={idx}
           disableGutters
+          expanded={isExpanded}
+          onChange={(_, exp) => setExpandedIdx(exp ? idx : null)}
           sx={{
             bgcolor: "background.paper",
             border: 1, borderColor: "divider", borderRadius: 2,
@@ -49,8 +57,14 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             }}>
               {previewReason(group.reasonText)}
             </Typography>
+            {/* Collapsed: read-only reason note chips, flush right before the count + arrow. */}
+            {!isExpanded && (
+              <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "40%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+                <InlineNotes scope="reason" entityId={`reason:${areaName ?? ""}:${idx}`} readOnly />
+              </Box>
+            )}
             <Box component="span" sx={{
-              ml: "auto", flexShrink: 0,
+              ml: isExpanded ? "auto" : 0, flexShrink: 0,
               bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20,
               px: 1.5, py: "3px", fontSize: 12, fontWeight: 700,
             }}>
@@ -58,6 +72,17 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             </Box>
           </AccordionSummary>
           <AccordionDetails sx={{ p: 0 }}>
+            {/* Expanded only: the single editable reason-level Add Note action.
+                Adding/editing/deleting cascades to every child test of this reason. */}
+            {isExpanded && (
+              <Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+                <InlineNotes
+                  scope="reason"
+                  entityId={`reason:${areaName ?? ""}:${idx}`}
+                  cascadeTo={group.tests.map((t) => `test:${areaName ?? ""}:${t.testName}`)}
+                />
+              </Box>
+            )}
             {/* Compact rows — same layout as the By Server / By Job tabs. */}
             <FailureRowList
               items={group.tests}
@@ -69,7 +94,8 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             />
           </AccordionDetails>
         </Accordion>
-      ))}
+        );
+      })}
     </Box>
   );
 };

--- a/client/src/components/ByReasonView.tsx
+++ b/client/src/components/ByReasonView.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Box, Typography, Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
 import FailureRowList from "./FailureRowList";
 import InlineNotes from "./InlineNotes";
 import type { ReasonGroup } from "../types/FailuresByReason";
@@ -57,10 +58,29 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             }}>
               {previewReason(group.reasonText)}
             </Typography>
-            {/* Collapsed: read-only reason note chips, flush right before the count + arrow. */}
+            {/* List view header: read-only reason chips + an Add trigger, on the far right.
+                The trigger expands the accordion so the editor opens below the title. */}
             {!isExpanded && (
-              <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "40%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
-                <InlineNotes testName={null} failureReason={group.reasonText} readOnly />
+              <Box sx={{ ml: "auto", display: "flex", alignItems: "center", gap: 1, minWidth: 0, maxWidth: "55%" }} onClick={(e) => e.stopPropagation()}>
+                <Box sx={{ display: "flex", minWidth: 0, overflow: "hidden" }}>
+                  <InlineNotes testName={null} failureReason={group.reasonText} readOnly />
+                </Box>
+                <Box
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Add note"
+                  onClick={(e) => { e.stopPropagation(); setExpandedIdx(idx); }}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); setExpandedIdx(idx); } }}
+                  sx={{
+                    display: "inline-flex", alignItems: "center", gap: 0.5, flexShrink: 0,
+                    border: "1px dashed", borderColor: "rgba(148,163,184,0.5)", borderRadius: 1.5,
+                    color: "#cbd5e1", cursor: "pointer", px: 1, py: 0.375, lineHeight: 1.6,
+                    "&:hover": { color: "#f1f5f9", borderColor: "#94a3b8", bgcolor: "rgba(148,163,184,0.12)" },
+                  }}
+                >
+                  <AddCommentOutlinedIcon sx={{ fontSize: 15 }} />
+                  <Typography variant="caption" sx={{ color: "inherit", fontWeight: 600, lineHeight: 1.6 }}>Add note</Typography>
+                </Box>
               </Box>
             )}
             <Box component="span" sx={{
@@ -74,7 +94,7 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
           <AccordionDetails sx={{ p: 0 }}>
             {/* Expanded only: the single editable reason-level (general) Add Note action. */}
             {isExpanded && (
-              <Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+              <Box data-testid="reason-note" sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
                 <InlineNotes testName={null} failureReason={group.reasonText} />
               </Box>
             )}
@@ -86,6 +106,7 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
               onOpenHistory={onOpenHistory}
               testRailUrlFor={testRailUrlFor}
               areaName={areaName}
+              reasonContext={group.reasonText}
             />
           </AccordionDetails>
         </Accordion>

--- a/client/src/components/ByReasonView.tsx
+++ b/client/src/components/ByReasonView.tsx
@@ -60,7 +60,7 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             {/* Collapsed: read-only reason note chips, flush right before the count + arrow. */}
             {!isExpanded && (
               <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "40%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
-                <InlineNotes scope="reason" entityId={`reason:${areaName ?? ""}:${idx}`} readOnly />
+                <InlineNotes testName={null} failureReason={group.reasonText} readOnly />
               </Box>
             )}
             <Box component="span" sx={{
@@ -72,15 +72,10 @@ const ByReasonView: React.FC<ByReasonViewProps> = ({
             </Box>
           </AccordionSummary>
           <AccordionDetails sx={{ p: 0 }}>
-            {/* Expanded only: the single editable reason-level Add Note action.
-                Adding/editing/deleting cascades to every child test of this reason. */}
+            {/* Expanded only: the single editable reason-level (general) Add Note action. */}
             {isExpanded && (
               <Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
-                <InlineNotes
-                  scope="reason"
-                  entityId={`reason:${areaName ?? ""}:${idx}`}
-                  cascadeTo={group.tests.map((t) => `test:${areaName ?? ""}:${t.testName}`)}
-                />
+                <InlineNotes testName={null} failureReason={group.reasonText} />
               </Box>
             )}
             {/* Compact rows — same layout as the By Server / By Job tabs. */}

--- a/client/src/components/FailureCard.tsx
+++ b/client/src/components/FailureCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Box, Typography, Button, Card, CardContent, Chip, Collapse, CircularProgress } from "@mui/material";
 import TerminalIcon from "@mui/icons-material/Terminal";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import ScreenshotPanel from "./ScreenshotPanel";
@@ -12,7 +13,8 @@ import {
   renderLogLines,
   truncateLogToTestScope,
   extractFatalPreview,
-  dateOnly,
+  formatDateTime,
+  formatDuration,
   severityColor,
 } from "./failureHelpers";
 import { getExpandedLog } from "../services/apiService";
@@ -35,6 +37,7 @@ export function latestFailedToGroupedItem(item: LatestFailedTestItem): RecentFai
       buildNumber: item.buildNumber,
       logLink: item.logLink,
       screenshotLink: item.screenshotLink,
+      duration: item.duration ?? null,
     },
   };
 }
@@ -258,9 +261,19 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
               </Typography>
               {primary.lastDate && (
                 <Typography variant="caption" sx={{ fontWeight: 600, color: "text.secondary", bgcolor: "action.hover", borderRadius: "4px", px: 0.875, py: "1px", border: 1, borderColor: "divider" }}>
-                  📅 {dateOnly(primary.lastDate)}
+                  📅 {formatDateTime(primary.lastDate)}
                 </Typography>
               )}
+              {(() => {
+                const dur = formatDuration({ ...(item as any), ...(item.lastFailure as any), ...(primary as any) });
+                if (!dur) return null;
+                // Match the Date element styling exactly (same caption + sx).
+                return (
+                  <Typography variant="caption" sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, fontWeight: 600, color: "text.secondary", bgcolor: "action.hover", borderRadius: "4px", px: 0.875, py: "1px", border: 1, borderColor: "divider" }}>
+                    <AccessTimeIcon sx={{ fontSize: 13 }} /> Runtime: {dur}
+                  </Typography>
+                );
+              })()}
             </Box>
             <ReasonBlock reason={primary} label="Primary Reason" testName={item.testName}
               onExpandLog={(lines, label) => onExpandLog(lines, item.testName, label)}
@@ -296,7 +309,7 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
                       </Typography>
                       {reason.lastDate && (
                         <Typography variant="caption" sx={{ fontWeight: 600, color: "text.secondary", bgcolor: "action.hover", borderRadius: "4px", px: 0.875, py: "1px", border: 1, borderColor: "divider" }}>
-                          📅 {dateOnly(reason.lastDate)}
+                          📅 {formatDateTime(reason.lastDate)}
                         </Typography>
                       )}
                     </Box>

--- a/client/src/components/FailureCard.tsx
+++ b/client/src/components/FailureCard.tsx
@@ -125,7 +125,7 @@ interface FailureCardProps {
   areaName?: string;
 }
 
-const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, onExpandLog, onOpenHistory, testRailUrl, areaName }) => {
+const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, onExpandLog, onOpenHistory, testRailUrl }) => {
   const [moreOpen, setMoreOpen] = useState(false);
   const primary = item.reasons[0] ?? null;
   const extra = item.reasons.slice(1, 3);
@@ -213,7 +213,7 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
         </Box>
 
         {/* Test-level notes */}
-        <InlineNotes scope="test" entityId={`test:${areaName ?? ""}:${item.testName}`} />
+        <InlineNotes testName={item.testName} failureReason={item.reasons[0]?.text ?? "General"} />
 
         {/* Primary reason — its action row also hosts History + TestRail so all
             buttons (Expand Log, Full Log, History, TR) sit side by side. */}

--- a/client/src/components/FailureCard.tsx
+++ b/client/src/components/FailureCard.tsx
@@ -6,6 +6,7 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import ScreenshotPanel from "./ScreenshotPanel";
 import InlineNotes from "./InlineNotes";
+import { useNotes } from "../hooks/useNotes";
 import {
   WINDOW_DAYS,
   renderLogLines,
@@ -46,9 +47,11 @@ interface ReasonBlockProps {
   testName: string;
   onExpandLog: (lines: string[], label: string) => void;
   extraActions?: React.ReactNode;
+  /** Primary reason hides its notes here because they render under the test name. */
+  hideNotes?: boolean;
 }
 
-const ReasonBlock: React.FC<ReasonBlockProps> = ({ reason, label, testName, onExpandLog, extraActions }) => {
+const ReasonBlock: React.FC<ReasonBlockProps> = ({ reason, label, testName, onExpandLog, extraActions, hideNotes }) => {
   const previewLines = extractFatalPreview(reason.text ?? "");
   const [logLoading, setLogLoading] = useState(false);
 
@@ -109,6 +112,13 @@ const ReasonBlock: React.FC<ReasonBlockProps> = ({ reason, label, testName, onEx
         )}
         {extraActions}
       </Box>
+
+      {/* Notes for THIS specific reason — its own block directly below the reason. */}
+      {!hideNotes && (
+        <div style={{ display: "block", marginTop: "8px", textAlign: "left" }}>
+          <InlineNotes testName={testName} failureReason={reason.text ?? "General"} />
+        </div>
+      )}
     </Box>
   );
 };
@@ -123,14 +133,25 @@ interface FailureCardProps {
   onOpenHistory: () => void;
   testRailUrl?: string | null;
   areaName?: string;
+  /** Reason this card is grouped under (By Reason tab) — surfaces cascaded global notes. */
+  reasonContext?: string;
 }
 
-const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, onExpandLog, onOpenHistory, testRailUrl }) => {
+const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, onExpandLog, onOpenHistory, testRailUrl, reasonContext }) => {
   const [moreOpen, setMoreOpen] = useState(false);
   const primary = item.reasons[0] ?? null;
   const extra = item.reasons.slice(1, 3);
   const screenshotSrc = item.reasons[0]?.screenshotLink ?? item.lastFailure.screenshotLink ?? null;
   const color = severityColor(item.failCount);
+
+  // DEBUG: surface the exact reason strings so we can see why cross-tab matching fails.
+  const { notes } = useNotes();
+  console.log("DEBUG REASON MATCH:", {
+    testName: item.testName,
+    testReason: item.reasons.map((r) => r.text),
+    reasonContext,
+    globalNotes: notes.filter((n) => n.testName === null).map((n) => ({ failureReason: n.failureReason, noteContent: n.noteContent })),
+  });
 
   // History + TestRail, rendered alongside Expand Log / Full Log in a single row.
   const actionButtons = (
@@ -212,8 +233,20 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
           </Box>
         </Box>
 
-        {/* Test-level notes */}
-        <InlineNotes testName={item.testName} failureReason={item.reasons[0]?.text ?? "General"} />
+        {/* Add Note for the main test — its own block directly below the title. */}
+        {reasonContext && !item.reasons.some((r) => (r.text ?? "General") === reasonContext) ? (
+          <div style={{ display: "block", marginTop: "8px", textAlign: "left" }}>
+            <InlineNotes testName={item.testName} failureReason={reasonContext} />
+          </div>
+        ) : item.reasons.length === 0 ? (
+          <div style={{ display: "block", marginTop: "8px", textAlign: "left" }}>
+            <InlineNotes testName={item.testName} failureReason="General" />
+          </div>
+        ) : (
+          <div style={{ display: "block", marginTop: "8px", textAlign: "left" }}>
+            <InlineNotes testName={item.testName} failureReason={item.reasons[0]?.text ?? "General"} />
+          </div>
+        )}
 
         {/* Primary reason — its action row also hosts History + TestRail so all
             buttons (Expand Log, Full Log, History, TR) sit side by side. */}
@@ -231,7 +264,7 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
             </Box>
             <ReasonBlock reason={primary} label="Primary Reason" testName={item.testName}
               onExpandLog={(lines, label) => onExpandLog(lines, item.testName, label)}
-              extraActions={actionButtons} />
+              extraActions={actionButtons} hideNotes />
           </Box>
         ) : (
           <Box sx={{ display: "flex", gap: 0.875, flexWrap: "wrap", pt: 0.5 }}>

--- a/client/src/components/FailureCard.tsx
+++ b/client/src/components/FailureCard.tsx
@@ -5,8 +5,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import ScreenshotPanel from "./ScreenshotPanel";
-import TestNoteButton from "./TestNoteButton";
-import TestNoteDisplay from "./TestNoteDisplay";
+import InlineNotes from "./InlineNotes";
 import {
   WINDOW_DAYS,
   renderLogLines,
@@ -202,7 +201,6 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
           <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, fontWeight: 600, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all", lineHeight: 1.5 }}>
             {item.testName}
           </Typography>
-          <TestNoteButton areaName={areaName} testName={item.testName} />
           {item.lastFailure.server && (
             <Chip label={`🖥️ ${item.lastFailure.server}`} size="small" variant="outlined" sx={{ fontSize: 11, color: "text.secondary", borderColor: "divider", flexShrink: 0 }} />
           )}
@@ -214,8 +212,8 @@ const FailureCard: React.FC<FailureCardProps> = ({ item, index, onImageClick, on
           </Box>
         </Box>
 
-        {/* Local note */}
-        <TestNoteDisplay areaName={areaName} testName={item.testName} />
+        {/* Test-level notes */}
+        <InlineNotes scope="test" entityId={`test:${areaName ?? ""}:${item.testName}`} />
 
         {/* Primary reason — its action row also hosts History + TestRail so all
             buttons (Expand Log, Full Log, History, TR) sit side by side. */}

--- a/client/src/components/FailureRowList.tsx
+++ b/client/src/components/FailureRowList.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { Box, Typography, Button, Paper, Collapse } from "@mui/material";
+import { Box, Typography, Button, Paper, Collapse, IconButton, Tooltip } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import FailureCard from "./FailureCard";
 import InlineNotes from "./InlineNotes";
 import type { RecentFailureGroupedItem } from "../types/RecentFailuresGrouped";
@@ -48,9 +49,19 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
               }}
             >
               <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "#ef4444", flexShrink: 0 }} />
-              <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
+              <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", minWidth: 0, flexShrink: 1, maxWidth: "55%", wordBreak: "break-all" }}>
                 {item.testName}
               </Typography>
+              <Tooltip title="Copy test name">
+                <IconButton
+                  size="small"
+                  aria-label="Copy test name"
+                  onClick={(e) => { e.stopPropagation(); navigator.clipboard?.writeText(item.testName); }}
+                  sx={{ flexShrink: 0, p: 0.25, ml: 0.25, color: "text.disabled", "&:hover": { color: "text.secondary" } }}
+                >
+                  <ContentCopyIcon sx={{ fontSize: 14 }} />
+                </IconButton>
+              </Tooltip>
               {/* List view: notes + Add control on the far right of the row. */}
               {!isOpen && (
                 <Box sx={{ ml: "auto", mr: 1, display: "flex", minWidth: 0, maxWidth: "55%", overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>

--- a/client/src/components/FailureRowList.tsx
+++ b/client/src/components/FailureRowList.tsx
@@ -53,8 +53,8 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
               {!isOpen && (
                 <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                   <InlineNotes
-                    scope="test"
-                    entityId={`test:${areaName ?? ""}:${item.testName}`}
+                    testName={item.testName}
+                    failureReason={item.reasons[0]?.text ?? "General"}
                     readOnly
                   />
                 </Box>

--- a/client/src/components/FailureRowList.tsx
+++ b/client/src/components/FailureRowList.tsx
@@ -51,7 +51,7 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
               </Typography>
               {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
               {!isOpen && (
-                <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+                <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                   <InlineNotes
                     scope="test"
                     entityId={`test:${areaName ?? ""}:${item.testName}`}
@@ -70,7 +70,7 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
                   onClick={(e) => e.stopPropagation()}
                   sx={{
                     borderColor: "#cbd5e1", color: "#475569", textTransform: "none",
-                    fontSize: 11, py: "3px", px: "10px", minHeight: 0, lineHeight: 1.4,
+                    fontSize: 11, py: "3px", px: "10px", minHeight: 0, lineHeight: 1.4, flexShrink: 0,
                     "&:hover": { borderColor: "#94a3b8", bgcolor: "background.paper", color: "text.primary" },
                   }}
                 >
@@ -84,7 +84,7 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
                 onClick={(e) => { e.stopPropagation(); onOpenHistory(item.testName); }}
                 sx={{
                   borderColor: "#cbd5e1", color: "#475569", textTransform: "none",
-                  fontSize: 11, py: "3px", px: "10px", minHeight: 0, lineHeight: 1.4,
+                  fontSize: 11, py: "3px", px: "10px", minHeight: 0, lineHeight: 1.4, flexShrink: 0,
                   "&:hover": { borderColor: "#94a3b8", bgcolor: "background.paper", color: "text.primary" },
                 }}
               >

--- a/client/src/components/FailureRowList.tsx
+++ b/client/src/components/FailureRowList.tsx
@@ -4,8 +4,7 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import FailureCard from "./FailureCard";
-import TestNoteButton from "./TestNoteButton";
-import TestNoteDisplay from "./TestNoteDisplay";
+import InlineNotes from "./InlineNotes";
 import type { RecentFailureGroupedItem } from "../types/RecentFailuresGrouped";
 
 interface FailureRowListProps {
@@ -50,7 +49,16 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
               <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                 {item.testName}
               </Typography>
-              <TestNoteButton areaName={areaName} testName={item.testName} stopPropagation />
+              {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
+              {!isOpen && (
+                <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+                  <InlineNotes
+                    scope="test"
+                    entityId={`test:${areaName ?? ""}:${item.testName}`}
+                    readOnly
+                  />
+                </Box>
+              )}
               {trUrl && (
                 <Button
                   size="small"
@@ -87,10 +95,6 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
                 transition: "transform 0.22s ease",
                 transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
               }} />
-            </Box>
-
-            <Box sx={{ px: 2, "&:not(:empty)": { pb: 1.25 } }}>
-              <TestNoteDisplay areaName={areaName} testName={item.testName} />
             </Box>
 
             <Collapse in={isOpen} unmountOnExit>

--- a/client/src/components/FailureRowList.tsx
+++ b/client/src/components/FailureRowList.tsx
@@ -14,11 +14,13 @@ interface FailureRowListProps {
   onOpenHistory: (testName: string) => void;
   testRailUrlFor: (testName: string) => string | null;
   areaName?: string;
+  /** Reason this list is grouped under (By Reason tab) — cascades global notes to rows. */
+  reasonContext?: string;
 }
 
 /** Compact, expandable list of failures (same look as the List View tab). */
 const FailureRowList: React.FC<FailureRowListProps> = ({
-  items, onImageClick, onExpandLog, onOpenHistory, testRailUrlFor, areaName,
+  items, onImageClick, onExpandLog, onOpenHistory, testRailUrlFor, areaName, reasonContext,
 }) => {
   const [openTestName, setOpenTestName] = useState<string | null>(null);
 
@@ -49,13 +51,13 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
               <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                 {item.testName}
               </Typography>
-              {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
+              {/* List view: notes + Add control on the far right of the row. */}
               {!isOpen && (
-                <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
+                <Box sx={{ ml: "auto", mr: 1, display: "flex", minWidth: 0, maxWidth: "55%", overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                   <InlineNotes
                     testName={item.testName}
-                    failureReason={item.reasons[0]?.text ?? "General"}
-                    readOnly
+                    failureReason={reasonContext ?? item.reasons[0]?.text ?? "General"}
+                    isListView
                   />
                 </Box>
               )}
@@ -112,6 +114,7 @@ const FailureRowList: React.FC<FailureRowListProps> = ({
                   onOpenHistory={() => onOpenHistory(item.testName)}
                   testRailUrl={trUrl}
                   areaName={areaName}
+                  reasonContext={reasonContext}
                 />
               </Box>
             </Collapse>

--- a/client/src/components/InlineNotes.tsx
+++ b/client/src/components/InlineNotes.tsx
@@ -1,0 +1,285 @@
+import React, { useCallback, useState, useSyncExternalStore } from "react";
+import { Box, Typography, TextField, IconButton, Tooltip, Link } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import StickyNote2OutlinedIcon from "@mui/icons-material/StickyNote2Outlined";
+import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+
+
+type NoteItem = { id: string; text: string };
+type NoteScope = "test" | "reason";
+
+const JIRA_BASE_URL = import.meta.env.VITE_JIRA_BASE_URL;
+const JIRA_TICKET_RE = /\b[A-Z]+-\d+\b/g;
+
+/**
+ * Renders note text with JIRA ticket IDs (e.g. URM-88888) turned into safe,
+ * clickable links. Splits the string and maps matches to React elements — no
+ * dangerouslySetInnerHTML, so user text is never interpreted as HTML.
+ */
+function renderNoteText(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  JIRA_TICKET_RE.lastIndex = 0;
+
+  while ((match = JIRA_TICKET_RE.exec(text)) !== null) {
+    const ticket = match[0];
+    if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index));
+    parts.push(
+      <Link
+        key={`${ticket}-${match.index}`}
+        href={`${JIRA_BASE_URL}${ticket}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        sx={{ color: "inherit", fontWeight: 700, textDecorationColor: "currentColor" }}
+      >
+        {ticket}
+      </Link>
+    );
+    lastIndex = match.index + ticket.length;
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  return parts;
+}
+
+const store = new Map<string, NoteItem[]>();
+const EMPTY: NoteItem[] = [];
+const listeners = new Set<() => void>();
+
+const emit = () => listeners.forEach((l) => l());
+const subscribe = (cb: () => void) => { listeners.add(cb); return () => { listeners.delete(cb); }; };
+
+let seq = 0;
+const newId = () => `note-${Date.now()}-${seq++}`;
+
+const pushNote = (id: string, text: string) =>
+  store.set(id, [...(store.get(id) ?? []), { id: newId(), text }]);
+const updateNote = (id: string, noteId: string, text: string) =>
+  store.set(id, (store.get(id) ?? []).map((n) => (n.id === noteId ? { ...n, text } : n)));
+const updateNoteByText = (id: string, oldText: string, text: string) =>
+  store.set(id, (store.get(id) ?? []).map((n) => (n.text === oldText ? { ...n, text } : n)));
+const deleteNote = (id: string, noteId: string) =>
+  store.set(id, (store.get(id) ?? []).filter((n) => n.id !== noteId));
+const deleteNoteByText = (id: string, text: string) =>
+  store.set(id, (store.get(id) ?? []).filter((n) => n.text !== text));
+
+function useInlineNotes(entityId: string) {
+  const notes = useSyncExternalStore(subscribe, () => store.get(entityId) ?? EMPTY);
+  // Adding can cascade the same note to related entities (e.g. all tests of a reason).
+  const add = useCallback((text: string, cascadeTo: string[] = []) => {
+    pushNote(entityId, text);
+    cascadeTo.forEach((id) => pushNote(id, text));
+    emit();
+  }, [entityId]);
+  // Editing cascades to the same related entities by matching the previous text.
+  const edit = useCallback((noteId: string, text: string, oldText: string, cascadeTo: string[] = []) => {
+    updateNote(entityId, noteId, text);
+    cascadeTo.forEach((id) => updateNoteByText(id, oldText, text));
+    emit();
+  }, [entityId]);
+  // Deleting cascades to the same related entities by matching note text.
+  const remove = useCallback((noteId: string, text: string, cascadeTo: string[] = []) => {
+    deleteNote(entityId, noteId);
+    cascadeTo.forEach((id) => deleteNoteByText(id, text));
+    emit();
+  }, [entityId]);
+  return { notes, add, edit, remove };
+}
+
+// ─── Inline editor (shared by add + edit flows) ───────────────────────────────
+
+interface NoteEditorProps {
+  initialValue: string;
+  placeholder: string;
+  onSave: (text: string) => void;
+  onCancel: () => void;
+}
+
+const NoteEditor: React.FC<NoteEditorProps> = ({ initialValue, placeholder, onSave, onCancel }) => {
+  const [draft, setDraft] = useState(initialValue);
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed) onSave(trimmed);
+    else onCancel();
+  };
+
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }} onClick={(e) => e.stopPropagation()}>
+      <TextField
+        autoFocus
+        size="small"
+        variant="outlined"
+        placeholder={placeholder}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commit(); }
+          if (e.key === "Escape") { e.preventDefault(); onCancel(); }
+        }}
+        sx={{
+          minWidth: 240,
+          "& .MuiOutlinedInput-root": { bgcolor: "background.paper", borderRadius: 1.5 },
+          "& .MuiOutlinedInput-input": { fontSize: 12.5, py: 0.5, color: "text.primary" },
+        }}
+      />
+      <Tooltip title="Save">
+        <IconButton size="small" aria-label="Save note" onClick={commit} sx={{ color: "text.secondary" }}>
+          <CheckIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Cancel">
+        <IconButton size="small" aria-label="Cancel note" onClick={onCancel} sx={{ color: "text.disabled" }}>
+          <CloseIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
+
+// ─── Note chip (view, + inline edit when not read-only) ───────────────────────
+
+interface NotePillProps {
+  note: NoteItem;
+  readOnly: boolean;
+  onEdit: (text: string) => void;
+  onDelete: () => void;
+}
+
+const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete }) => {
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <NoteEditor
+        initialValue={note.text}
+        placeholder="Edit note…"
+        onSave={(text) => { onEdit(text); setEditing(false); }}
+        onCancel={() => setEditing(false)}
+      />
+    );
+  }
+
+  return (
+    <Box
+      onClick={(e) => e.stopPropagation()}
+      sx={{
+        display: "inline-flex", alignItems: "center", gap: 0.625, maxWidth: "100%",
+        // Prominent, intuitive "sticky note" amber — high contrast, not alarming.
+        bgcolor: (t) => alpha(t.palette.warning.main, t.palette.mode === "dark" ? 0.22 : 0.16),
+        border: 1,
+        borderColor: (t) => alpha(t.palette.warning.main, 0.5),
+        color: (t) => (t.palette.mode === "dark" ? t.palette.warning.light : t.palette.warning.dark),
+        borderRadius: 1.5, pl: 1, pr: readOnly ? 1 : 0.5, py: 0.375,
+        transition: "border-color 0.15s, background-color 0.15s",
+        ...(!readOnly && {
+          "&:hover": { borderColor: (t) => alpha(t.palette.warning.main, 0.85) },
+          "&:hover .note-actions": { opacity: 1, width: "auto", ml: 0.25 },
+        }),
+      }}
+    >
+      <StickyNote2OutlinedIcon sx={{ fontSize: 15, color: "inherit", flexShrink: 0 }} />
+      <Typography
+        variant="caption"
+        sx={{ color: "inherit", fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", lineHeight: 1.6 }}
+      >
+        {renderNoteText(note.text)}
+      </Typography>
+      {!readOnly && (
+        <Box
+          className="note-actions"
+          sx={{ display: "inline-flex", alignItems: "center", opacity: 0, width: 0, overflow: "hidden", transition: "opacity 0.15s" }}
+        >
+          <Tooltip title="Edit note">
+            <IconButton size="small" aria-label="Edit note" onClick={() => setEditing(true)} sx={{ p: 0.25, color: "inherit", opacity: 0.75, "&:hover": { opacity: 1 } }}>
+              <EditOutlinedIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete note">
+            <IconButton size="small" aria-label="Delete note" onClick={onDelete} sx={{ p: 0.25, color: "inherit", opacity: 0.75, "&:hover": { opacity: 1 } }}>
+              <DeleteOutlineIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+// ─── Inline notes container ───────────────────────────────────────────────────
+
+interface InlineNotesProps {
+  /** Whether the note is attached to a single test or to a failure reason. */
+  scope: NoteScope;
+  /** Stable identity of the note target. */
+  entityId: string;
+  /** When true (collapsed/list view): show existing chips only, no write actions. */
+  readOnly?: boolean;
+  /** Extra entityIds a newly added note should also be applied to (cascade). */
+  cascadeTo?: string[];
+}
+
+const InlineNotes: React.FC<InlineNotesProps> = ({ scope, entityId, readOnly = false, cascadeTo }) => {
+  const { notes, add, edit, remove } = useInlineNotes(entityId);
+  const [adding, setAdding] = useState(false);
+
+  // Collapsed/read-only with nothing to show → render nothing.
+  if (readOnly && notes.length === 0) return null;
+
+  const placeholder = scope === "reason" ? "Note for this reason…" : "Note for this test…";
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.75 }}>
+      {notes.map((note) => (
+        <NotePill
+          key={note.id}
+          note={note}
+          readOnly={readOnly}
+          onEdit={(text) => edit(note.id, text, note.text, cascadeTo)}
+          onDelete={() => remove(note.id, note.text, cascadeTo)}
+        />
+      ))}
+
+      {!readOnly && (adding ? (
+        <NoteEditor
+          initialValue=""
+          placeholder={placeholder}
+          onSave={(text) => { add(text, cascadeTo); setAdding(false); }}
+          onCancel={() => setAdding(false)}
+        />
+      ) : (
+        <Tooltip title="Add note">
+          <Box
+            component="button"
+            type="button"
+            aria-label="Add note"
+            onClick={(e) => { e.stopPropagation(); setAdding(true); }}
+            sx={{
+              display: "inline-flex", alignItems: "center", gap: 0.5,
+              border: "1px dashed", borderColor: "divider", borderRadius: 1.5,
+              bgcolor: "transparent", color: "text.secondary", cursor: "pointer",
+              px: 1, py: 0.375, font: "inherit", lineHeight: 1.6,
+              transition: "color 0.15s, border-color 0.15s, background-color 0.15s",
+              "&:hover": {
+                color: "text.primary",
+                borderColor: "text.secondary",
+                bgcolor: "action.hover",
+              },
+            }}
+          >
+            <AddCommentOutlinedIcon sx={{ fontSize: 15 }} />
+            <Typography variant="caption" sx={{ color: "inherit", fontWeight: 600, lineHeight: 1.6 }}>
+              Add note
+            </Typography>
+          </Box>
+        </Tooltip>
+      ))}
+    </Box>
+  );
+};
+
+export default InlineNotes;

--- a/client/src/components/InlineNotes.tsx
+++ b/client/src/components/InlineNotes.tsx
@@ -2,12 +2,13 @@ import React, { useState } from "react";
 import { Box, Typography, TextField, IconButton, Tooltip, Link } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import StickyNote2OutlinedIcon from "@mui/icons-material/StickyNote2Outlined";
+import PublicOutlinedIcon from "@mui/icons-material/PublicOutlined";
 import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
-import { useNotes, selectNotes } from "../hooks/useNotes";
+import { useNotes } from "../hooks/useNotes";
 import type { FailureNote } from "../services/apiService";
 
 // FAILURE_REASON column is VARCHAR2(1000); cap the key so it always fits the DB.
@@ -16,6 +17,20 @@ const MAX_REASON_LEN = 1000;
 // JIRA base comes from the Vite env (VITE_JIRA_BASE_URL); fallback keeps links working.
 const JIRA_BASE_URL = import.meta.env.VITE_JIRA_BASE_URL || "https://default.atlassian.net/browse/";
 const JIRA_TICKET_RE = /\b[A-Z]+-\d+\b/g;
+
+// ── Slate-blue / muted-indigo note palette (blends with the dark dashboard). ──
+type Tone = "indigo" | "slate";
+const toneSx = (tone: Tone) => {
+  const hue = tone === "indigo"
+    ? { dark: "#a5b4fc", light: "#6366f1", text: { dark: "#c7d2fe", light: "#4338ca" } }
+    : { dark: "#cbd5e1", light: "#64748b", text: { dark: "#cbd5e1", light: "#475569" } };
+  return {
+    bgcolor: (t: any) => alpha(t.palette.mode === "dark" ? hue.dark : hue.light, t.palette.mode === "dark" ? 0.16 : 0.1),
+    borderColor: (t: any) => alpha(t.palette.mode === "dark" ? hue.dark : hue.light, 0.4),
+    color: (t: any) => (t.palette.mode === "dark" ? hue.text.dark : hue.text.light),
+    hoverBorder: (t: any) => alpha(t.palette.mode === "dark" ? hue.dark : hue.light, 0.75),
+  };
+};
 
 /**
  * Renders note text with JIRA ticket IDs (e.g. URM-88888) turned into safe,
@@ -103,13 +118,17 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ initialValue, placeholder, onSa
 
 interface NotePillProps {
   note: FailureNote;
+  tone: Tone;
   readOnly: boolean;
+  /** Inherited global note (testName null) shown on a test — labelled, never editable here. */
+  inherited?: boolean;
   onEdit: (text: string) => void;
   onDelete: () => void;
 }
 
-const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete }) => {
+const NotePill: React.FC<NotePillProps> = ({ note, tone, readOnly, inherited, onEdit, onDelete }) => {
   const [editing, setEditing] = useState(false);
+  const c = toneSx(tone);
 
   if (editing) {
     return (
@@ -122,32 +141,34 @@ const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete })
     );
   }
 
+  const showActions = !readOnly && !inherited;
+
   return (
     <Box
       onClick={(e) => e.stopPropagation()}
       sx={{
         display: "inline-flex", alignItems: "center", gap: 0.625, maxWidth: "100%",
-        // Prominent, intuitive "sticky note" amber — high contrast, not alarming.
-        bgcolor: (t) => alpha(t.palette.warning.main, t.palette.mode === "dark" ? 0.22 : 0.16),
-        border: 1,
-        borderColor: (t) => alpha(t.palette.warning.main, 0.5),
-        color: (t) => (t.palette.mode === "dark" ? t.palette.warning.light : t.palette.warning.dark),
-        borderRadius: 1.5, pl: 1, pr: readOnly ? 1 : 0.5, py: 0.375,
+        bgcolor: c.bgcolor, border: 1, borderColor: c.borderColor, color: c.color,
+        borderRadius: 1.5, pl: 1, pr: showActions ? 0.5 : 1, py: 0.375,
         transition: "border-color 0.15s, background-color 0.15s",
-        ...(!readOnly && {
-          "&:hover": { borderColor: (t) => alpha(t.palette.warning.main, 0.85) },
+        ...(showActions && {
+          "&:hover": { borderColor: c.hoverBorder },
           "&:hover .note-actions": { opacity: 1, width: "auto", ml: 0.25 },
         }),
       }}
     >
-      <StickyNote2OutlinedIcon sx={{ fontSize: 15, color: "inherit", flexShrink: 0 }} />
+      <Tooltip title={inherited ? "Global note for this reason" : ""} disableHoverListener={!inherited}>
+        {inherited
+          ? <PublicOutlinedIcon sx={{ fontSize: 15, color: "inherit", flexShrink: 0 }} />
+          : <StickyNote2OutlinedIcon sx={{ fontSize: 15, color: "inherit", flexShrink: 0 }} />}
+      </Tooltip>
       <Typography
         variant="caption"
         sx={{ color: "inherit", fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", lineHeight: 1.6 }}
       >
         {renderNoteText(note.noteContent)}
       </Typography>
-      {!readOnly && (
+      {showActions && (
         <Box
           className="note-actions"
           sx={{ display: "inline-flex", alignItems: "center", opacity: 0, width: 0, overflow: "hidden", transition: "opacity 0.15s" }}
@@ -177,20 +198,29 @@ interface InlineNotesProps {
   failureReason: string;
   /** When true (collapsed/list view): show existing chips only, no write actions. */
   readOnly?: boolean;
+  /** List view (collapsed rows/headers): right-align the Add control. Card view: block under text. */
+  isListView?: boolean;
 }
 
-const InlineNotes: React.FC<InlineNotesProps> = ({ testName, failureReason, readOnly = false }) => {
-  const { notes, add, remove } = useNotes();
+const MAX_NOTES_PER_ITEM = 5;
+
+const InlineNotes: React.FC<InlineNotesProps> = ({ testName, failureReason, readOnly = false, isListView = false }) => {
+  const { add, remove, notesForItem } = useNotes();
   const [adding, setAdding] = useState(false);
 
   const tn = typeof testName === "string" && testName.trim() !== "" ? testName.trim() : null;
   const reason = (failureReason ?? "").slice(0, MAX_REASON_LEN);
-  const mine = selectNotes(notes, tn, reason);
-
-  // Collapsed/read-only with nothing to show → render nothing.
-  if (readOnly && mine.length === 0) return null;
-
   const isGeneral = tn === null;
+
+  // Relational getter: this item's private notes + global notes for the same reason.
+  const all = notesForItem(tn, reason);
+  const own = all.filter((n) => n.testName === tn);
+  const inherited = isGeneral ? [] : all.filter((n) => n.testName === null);
+
+  if (readOnly && own.length === 0 && inherited.length === 0) return null;
+
+  const atLimit = own.length >= MAX_NOTES_PER_ITEM;
+
   const addTooltip = isGeneral
     ? "Add a note to all tests failing with this reason"
     : "Add a note to this specific test only";
@@ -199,35 +229,49 @@ const InlineNotes: React.FC<InlineNotesProps> = ({ testName, failureReason, read
   const handleAdd = (text: string) => { add(tn, reason, text); setAdding(false); };
   const handleEdit = (note: FailureNote, text: string) => { remove(note.noteId).then(() => add(tn, reason, text)); };
 
+  // List view: push the Add control to the far right. Card view: keep it under the text.
+  const mlAuto = isListView ? "auto" : undefined;
+
   return (
     <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.75 }}>
-      {mine.map((note) => (
+      {/* Inherited global notes (read-only here; managed from the reason view). */}
+      {inherited.map((note) => (
+        <NotePill key={`g-${note.noteId}`} note={note} tone="slate" readOnly inherited onEdit={() => {}} onDelete={() => {}} />
+      ))}
+
+      {/* Own notes — multiple allowed. */}
+      {own.map((note) => (
         <NotePill
           key={note.noteId}
           note={note}
+          tone="indigo"
           readOnly={readOnly}
           onEdit={(text) => handleEdit(note, text)}
           onDelete={() => remove(note.noteId)}
         />
       ))}
 
-      {/* Unique (TEST_NAME, FAILURE_REASON) → only offer Add when none exists yet. */}
-      {!readOnly && mine.length === 0 && (adding ? (
-        <NoteEditor
-          initialValue=""
-          placeholder={placeholder}
-          onSave={handleAdd}
-          onCancel={() => setAdding(false)}
-        />
+      {!readOnly && !atLimit && (adding ? (
+        <Box sx={{ ml: mlAuto, display: "inline-flex" }}>
+          <NoteEditor
+            initialValue=""
+            placeholder={placeholder}
+            onSave={handleAdd}
+            onCancel={() => setAdding(false)}
+          />
+        </Box>
       ) : (
         <Tooltip title={addTooltip}>
           <Box
-            component="button"
-            type="button"
+            role="button"
+            tabIndex={0}
             aria-label="Add note"
             onClick={(e) => { e.stopPropagation(); setAdding(true); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); setAdding(true); }
+            }}
             sx={{
-              display: "inline-flex", alignItems: "center", gap: 0.5,
+              display: "inline-flex", alignItems: "center", gap: 0.5, ml: mlAuto,
               border: "1px dashed", borderColor: "divider", borderRadius: 1.5,
               bgcolor: "transparent", color: "text.secondary", cursor: "pointer",
               px: 1, py: 0.375, font: "inherit", lineHeight: 1.6,
@@ -246,6 +290,13 @@ const InlineNotes: React.FC<InlineNotesProps> = ({ testName, failureReason, read
           </Box>
         </Tooltip>
       ))}
+
+      {/* At the 5-note cap, surface a subtle hint instead of the Add button. */}
+      {!readOnly && atLimit && (
+        <Typography variant="caption" sx={{ ml: mlAuto, color: "text.disabled", fontStyle: "italic" }}>
+          Max {MAX_NOTES_PER_ITEM} notes
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/client/src/components/InlineNotes.tsx
+++ b/client/src/components/InlineNotes.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useSyncExternalStore } from "react";
+import React, { useState } from "react";
 import { Box, Typography, TextField, IconButton, Tooltip, Link } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import StickyNote2OutlinedIcon from "@mui/icons-material/StickyNote2Outlined";
@@ -7,12 +7,14 @@ import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
+import { useNotes, selectNotes } from "../hooks/useNotes";
+import type { FailureNote } from "../services/apiService";
 
+// FAILURE_REASON column is VARCHAR2(1000); cap the key so it always fits the DB.
+const MAX_REASON_LEN = 1000;
 
-type NoteItem = { id: string; text: string };
-type NoteScope = "test" | "reason";
-
-const JIRA_BASE_URL = import.meta.env.VITE_JIRA_BASE_URL;
+// JIRA base comes from the Vite env (VITE_JIRA_BASE_URL); fallback keeps links working.
+const JIRA_BASE_URL = import.meta.env.VITE_JIRA_BASE_URL || "https://default.atlassian.net/browse/";
 const JIRA_TICKET_RE = /\b[A-Z]+-\d+\b/g;
 
 /**
@@ -45,50 +47,6 @@ function renderNoteText(text: string): React.ReactNode {
   }
   if (lastIndex < text.length) parts.push(text.slice(lastIndex));
   return parts;
-}
-
-const store = new Map<string, NoteItem[]>();
-const EMPTY: NoteItem[] = [];
-const listeners = new Set<() => void>();
-
-const emit = () => listeners.forEach((l) => l());
-const subscribe = (cb: () => void) => { listeners.add(cb); return () => { listeners.delete(cb); }; };
-
-let seq = 0;
-const newId = () => `note-${Date.now()}-${seq++}`;
-
-const pushNote = (id: string, text: string) =>
-  store.set(id, [...(store.get(id) ?? []), { id: newId(), text }]);
-const updateNote = (id: string, noteId: string, text: string) =>
-  store.set(id, (store.get(id) ?? []).map((n) => (n.id === noteId ? { ...n, text } : n)));
-const updateNoteByText = (id: string, oldText: string, text: string) =>
-  store.set(id, (store.get(id) ?? []).map((n) => (n.text === oldText ? { ...n, text } : n)));
-const deleteNote = (id: string, noteId: string) =>
-  store.set(id, (store.get(id) ?? []).filter((n) => n.id !== noteId));
-const deleteNoteByText = (id: string, text: string) =>
-  store.set(id, (store.get(id) ?? []).filter((n) => n.text !== text));
-
-function useInlineNotes(entityId: string) {
-  const notes = useSyncExternalStore(subscribe, () => store.get(entityId) ?? EMPTY);
-  // Adding can cascade the same note to related entities (e.g. all tests of a reason).
-  const add = useCallback((text: string, cascadeTo: string[] = []) => {
-    pushNote(entityId, text);
-    cascadeTo.forEach((id) => pushNote(id, text));
-    emit();
-  }, [entityId]);
-  // Editing cascades to the same related entities by matching the previous text.
-  const edit = useCallback((noteId: string, text: string, oldText: string, cascadeTo: string[] = []) => {
-    updateNote(entityId, noteId, text);
-    cascadeTo.forEach((id) => updateNoteByText(id, oldText, text));
-    emit();
-  }, [entityId]);
-  // Deleting cascades to the same related entities by matching note text.
-  const remove = useCallback((noteId: string, text: string, cascadeTo: string[] = []) => {
-    deleteNote(entityId, noteId);
-    cascadeTo.forEach((id) => deleteNoteByText(id, text));
-    emit();
-  }, [entityId]);
-  return { notes, add, edit, remove };
 }
 
 // ─── Inline editor (shared by add + edit flows) ───────────────────────────────
@@ -144,7 +102,7 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ initialValue, placeholder, onSa
 // ─── Note chip (view, + inline edit when not read-only) ───────────────────────
 
 interface NotePillProps {
-  note: NoteItem;
+  note: FailureNote;
   readOnly: boolean;
   onEdit: (text: string) => void;
   onDelete: () => void;
@@ -156,7 +114,7 @@ const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete })
   if (editing) {
     return (
       <NoteEditor
-        initialValue={note.text}
+        initialValue={note.noteContent}
         placeholder="Edit note…"
         onSave={(text) => { onEdit(text); setEditing(false); }}
         onCancel={() => setEditing(false)}
@@ -187,7 +145,7 @@ const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete })
         variant="caption"
         sx={{ color: "inherit", fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", lineHeight: 1.6 }}
       >
-        {renderNoteText(note.text)}
+        {renderNoteText(note.noteContent)}
       </Typography>
       {!readOnly && (
         <Box
@@ -213,46 +171,56 @@ const NotePill: React.FC<NotePillProps> = ({ note, readOnly, onEdit, onDelete })
 // ─── Inline notes container ───────────────────────────────────────────────────
 
 interface InlineNotesProps {
-  /** Whether the note is attached to a single test or to a failure reason. */
-  scope: NoteScope;
-  /** Stable identity of the note target. */
-  entityId: string;
+  /** Test the note is attached to. null/undefined/empty → general reason note. */
+  testName?: string | null;
+  /** The failure reason the note belongs to (DB FAILURE_REASON, NOT NULL). */
+  failureReason: string;
   /** When true (collapsed/list view): show existing chips only, no write actions. */
   readOnly?: boolean;
-  /** Extra entityIds a newly added note should also be applied to (cascade). */
-  cascadeTo?: string[];
 }
 
-const InlineNotes: React.FC<InlineNotesProps> = ({ scope, entityId, readOnly = false, cascadeTo }) => {
-  const { notes, add, edit, remove } = useInlineNotes(entityId);
+const InlineNotes: React.FC<InlineNotesProps> = ({ testName, failureReason, readOnly = false }) => {
+  const { notes, add, remove } = useNotes();
   const [adding, setAdding] = useState(false);
 
-  // Collapsed/read-only with nothing to show → render nothing.
-  if (readOnly && notes.length === 0) return null;
+  const tn = typeof testName === "string" && testName.trim() !== "" ? testName.trim() : null;
+  const reason = (failureReason ?? "").slice(0, MAX_REASON_LEN);
+  const mine = selectNotes(notes, tn, reason);
 
-  const placeholder = scope === "reason" ? "Note for this reason…" : "Note for this test…";
+  // Collapsed/read-only with nothing to show → render nothing.
+  if (readOnly && mine.length === 0) return null;
+
+  const isGeneral = tn === null;
+  const addTooltip = isGeneral
+    ? "Add a note to all tests failing with this reason"
+    : "Add a note to this specific test only";
+  const placeholder = isGeneral ? "Note for this reason…" : "Note for this test…";
+
+  const handleAdd = (text: string) => { add(tn, reason, text); setAdding(false); };
+  const handleEdit = (note: FailureNote, text: string) => { remove(note.noteId).then(() => add(tn, reason, text)); };
 
   return (
     <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.75 }}>
-      {notes.map((note) => (
+      {mine.map((note) => (
         <NotePill
-          key={note.id}
+          key={note.noteId}
           note={note}
           readOnly={readOnly}
-          onEdit={(text) => edit(note.id, text, note.text, cascadeTo)}
-          onDelete={() => remove(note.id, note.text, cascadeTo)}
+          onEdit={(text) => handleEdit(note, text)}
+          onDelete={() => remove(note.noteId)}
         />
       ))}
 
-      {!readOnly && (adding ? (
+      {/* Unique (TEST_NAME, FAILURE_REASON) → only offer Add when none exists yet. */}
+      {!readOnly && mine.length === 0 && (adding ? (
         <NoteEditor
           initialValue=""
           placeholder={placeholder}
-          onSave={(text) => { add(text, cascadeTo); setAdding(false); }}
+          onSave={handleAdd}
           onCancel={() => setAdding(false)}
         />
       ) : (
-        <Tooltip title="Add note">
+        <Tooltip title={addTooltip}>
           <Box
             component="button"
             type="button"

--- a/client/src/components/SearchWithHistory.tsx
+++ b/client/src/components/SearchWithHistory.tsx
@@ -16,10 +16,12 @@ interface SearchWithHistoryProps {
   placeholder?: string;
   fullWidth?: boolean;
   sx?: SxProps<Theme>;
+  /** When true, pressing Enter saves the raw typed query to history. */
+  saveTypedQueries?: boolean;
 }
 
 const SearchWithHistory: React.FC<SearchWithHistoryProps> = ({
-  value, onSearch, storageKey, placeholder = "Search…", fullWidth = false, sx,
+  value, onSearch, storageKey, placeholder = "Search…", fullWidth = false, sx, saveTypedQueries = false,
 }) => {
   const { history, remove, push } = useSearchHistory(storageKey);
   const [open, setOpen] = useState(false);
@@ -41,6 +43,12 @@ const SearchWithHistory: React.FC<SearchWithHistoryProps> = ({
           onFocus={() => setOpen(true)}
           onClick={() => setOpen(true)}
           onChange={(e) => onSearch(e.target.value)}
+          onKeyDown={(e) => {
+            if (saveTypedQueries && e.key === "Enter" && value.trim()) {
+              push(value);
+              setOpen(false);
+            }
+          }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">

--- a/client/src/components/__tests__/AreaCard.test.tsx
+++ b/client/src/components/__tests__/AreaCard.test.tsx
@@ -16,7 +16,11 @@ function renderCard() {
         env="qa"
         health={{ healthy: 7, medium: 5, bad: 3, dead: 5 }}
         // Providing trendData prevents the component's on-mount fetch.
-        trendData={[{ date: "2026-06-10", passed: 1, failed: 0, total: 1 }]}
+        // The big % now reflects the LATEST day (last point): 17/20 = 85%.
+        trendData={[
+          { date: "2026-06-09", passed: 2, failed: 8, total: 10 },
+          { date: "2026-06-10", passed: 17, failed: 3, total: 20 },
+        ]}
       />
     </MemoryRouter>,
   );
@@ -35,5 +39,50 @@ describe("AreaCard", () => {
     expect(screen.getByText(/Medium: 5/)).toBeInTheDocument();
     expect(screen.getByText(/Bad: 3/)).toBeInTheDocument();
     expect(screen.getByText(/Dead: 5/)).toBeInTheDocument();
+  });
+
+  it("shows the LAST day's pass rate, not the average of the trend", () => {
+    // Averages would be ~57%/~50%; the latest day (3/4) must win → 75%.
+    render(
+      <MemoryRouter>
+        <AreaCard
+          areaName="LOD"
+          displayName="Linked Open Data"
+          passRate={99}
+          total={4}
+          passed={3}
+          failed={1}
+          env="qa"
+          trendData={[
+            { date: "2026-06-08", passed: 1, failed: 9, total: 10 },  // 10%
+            { date: "2026-06-09", passed: 9, failed: 1, total: 10 },  // 90%
+            { date: "2026-06-10", passed: 3, failed: 1, total: 4 },   // 75% (latest)
+          ]}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.queryByText("99%")).toBeNull(); // not the prop/average
+  });
+
+  it("ignores trailing no-data days and uses the right-most day WITH data", () => {
+    render(
+      <MemoryRouter>
+        <AreaCard
+          areaName="LOD"
+          displayName="Linked Open Data"
+          passRate={0}
+          total={0}
+          passed={0}
+          failed={0}
+          env="qa"
+          trendData={[
+            { date: "2026-06-09", passed: 5, failed: 5, total: 10 },  // 50%
+            { date: "2026-06-10", passed: 0, failed: 0, total: 0 },   // no data
+          ]}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("50%")).toBeInTheDocument();
   });
 });

--- a/client/src/components/__tests__/ByReasonView.test.tsx
+++ b/client/src/components/__tests__/ByReasonView.test.tsx
@@ -1,11 +1,26 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import ByReasonView from "../ByReasonView";
+import * as api from "../../services/apiService";
+import { __resetNotesCacheForTests } from "../../hooks/useNotes";
 import type { ReasonGroup } from "../../types/FailuresByReason";
+
+// In-memory fake notes backend.
+let db: Array<{ noteId: number; testName: string | null; failureReason: string; noteContent: string; createdAt: string | null }>;
+let seq: number;
 
 vi.mock("../../services/apiService", () => ({
   getExpandedLog: vi.fn(() => new Promise(() => {})),
+  getNotes: vi.fn(async () => db),
+  createNote: vi.fn(async (testName: string | null, failureReason: string, content: string) => {
+    const note = { noteId: ++seq, testName: testName ?? null, failureReason, noteContent: content, createdAt: null };
+    db.push(note);
+    return note;
+  }),
+  deleteNote: vi.fn(async (id: number) => { db = db.filter((n) => n.noteId !== id); }),
 }));
+
+beforeEach(() => { db = []; seq = 0; __resetNotesCacheForTests(); vi.clearAllMocks(); });
 
 const reasons: ReasonGroup[] = [
   {
@@ -18,11 +33,11 @@ const reasons: ReasonGroup[] = [
   },
 ];
 
-function renderView(areaName = "LOD") {
+function renderView() {
   return render(
     <ByReasonView
       reasons={reasons}
-      areaName={areaName}
+      areaName="LOD"
       onImageClick={() => {}}
       onExpandLog={() => {}}
       onOpenHistory={() => {}}
@@ -31,7 +46,7 @@ function renderView(areaName = "LOD") {
   );
 }
 
-function addReasonNote(region: HTMLElement, text: string) {
+async function addReasonNote(region: HTMLElement, text: string) {
   fireEvent.click(within(region).getByRole("button", { name: "Add note" }));
   fireEvent.change(within(region).getByPlaceholderText(/Note for this reason/i), { target: { value: text } });
   fireEvent.click(within(region).getByLabelText("Save note"));
@@ -51,39 +66,24 @@ describe("ByReasonView", () => {
 
     fireEvent.click(summary);
     expect(summary).toHaveAttribute("aria-expanded", "true");
-    // After expanding, the grouped tests are shown.
     const region = screen.getByRole("region");
     expect(within(region).getByText("Test_A")).toBeInTheDocument();
   });
 });
 
 describe("ByReasonView — inline notes", () => {
-  it("shows the reason note label when collapsed but hides the write actions", () => {
-    renderView("BR1");
+  it("adds a general reason note (null testName) and shows it collapsed without write actions", async () => {
+    renderView();
     const summary = screen.getByRole("button", { name: /FATAL element not found/i });
 
-    fireEvent.click(summary); // expand → reason-level Add note action is available
-    addReasonNote(screen.getByRole("region"), "infra note");
+    fireEvent.click(summary); // expand → reason-level Add note action available
+    await addReasonNote(screen.getByRole("region"), "infra note");
+    expect(await screen.findByText("infra note")).toBeInTheDocument();
+    expect(api.createNote).toHaveBeenCalledWith(null, "FATAL element not found", "infra note");
 
     fireEvent.click(summary); // collapse
     expect(summary).toHaveAttribute("aria-expanded", "false");
-    // Label stays readable in the collapsed list view…
-    expect(screen.getAllByText("infra note").length).toBeGreaterThan(0);
-    // …but no write actions are rendered while collapsed.
-    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
-  });
-
-  it("cascades an added reason note to all child test rows and clears them on delete", () => {
-    renderView("BR2");
-    const summary = screen.getByRole("button", { name: /FATAL element not found/i });
-    fireEvent.click(summary);
-    const region = screen.getByRole("region");
-
-    addReasonNote(region, "cascade-xyz");
-    // Reason chip + Test_A row chip + Test_B row chip.
-    expect(screen.getAllByText("cascade-xyz")).toHaveLength(3);
-
-    fireEvent.click(within(region).getByLabelText("Delete note"));
-    expect(screen.queryByText("cascade-xyz")).toBeNull();
+    expect(screen.getByText("infra note")).toBeInTheDocument();          // label still readable
+    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull(); // no write actions
   });
 });

--- a/client/src/components/__tests__/ByReasonView.test.tsx
+++ b/client/src/components/__tests__/ByReasonView.test.tsx
@@ -46,10 +46,11 @@ function renderView() {
   );
 }
 
-async function addReasonNote(region: HTMLElement, text: string) {
-  fireEvent.click(within(region).getByRole("button", { name: "Add note" }));
-  fireEvent.change(within(region).getByPlaceholderText(/Note for this reason/i), { target: { value: text } });
-  fireEvent.click(within(region).getByLabelText("Save note"));
+async function addReasonNote(text: string) {
+  const editor = screen.getByTestId("reason-note");
+  fireEvent.click(within(editor).getByRole("button", { name: "Add note" }));
+  fireEvent.change(within(editor).getByPlaceholderText(/Note for this reason/i), { target: { value: text } });
+  fireEvent.click(within(editor).getByLabelText("Save note"));
 }
 
 describe("ByReasonView", () => {
@@ -77,13 +78,14 @@ describe("ByReasonView — inline notes", () => {
     const summary = screen.getByRole("button", { name: /FATAL element not found/i });
 
     fireEvent.click(summary); // expand → reason-level Add note action available
-    await addReasonNote(screen.getByRole("region"), "infra note");
-    expect(await screen.findByText("infra note")).toBeInTheDocument();
+    await addReasonNote("infra note");
+    // Cascades: reason chip + each child test row shows the global note.
+    expect((await screen.findAllByText("infra note")).length).toBeGreaterThanOrEqual(2);
     expect(api.createNote).toHaveBeenCalledWith(null, "FATAL element not found", "infra note");
 
     fireEvent.click(summary); // collapse
     expect(summary).toHaveAttribute("aria-expanded", "false");
-    expect(screen.getByText("infra note")).toBeInTheDocument();          // label still readable
-    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull(); // no write actions
-  });
+    expect(screen.getAllByText("infra note").length).toBeGreaterThan(0);              // label still readable
+    expect(screen.getAllByRole("button", { name: "Add note" }).length).toBeGreaterThan(0); // Add trigger on the right
+  }, 15000);
 });

--- a/client/src/components/__tests__/ByReasonView.test.tsx
+++ b/client/src/components/__tests__/ByReasonView.test.tsx
@@ -18,17 +18,23 @@ const reasons: ReasonGroup[] = [
   },
 ];
 
-function renderView() {
+function renderView(areaName = "LOD") {
   return render(
     <ByReasonView
       reasons={reasons}
-      areaName="LOD"
+      areaName={areaName}
       onImageClick={() => {}}
       onExpandLog={() => {}}
       onOpenHistory={() => {}}
       testRailUrlFor={() => null}
     />,
   );
+}
+
+function addReasonNote(region: HTMLElement, text: string) {
+  fireEvent.click(within(region).getByRole("button", { name: "Add note" }));
+  fireEvent.change(within(region).getByPlaceholderText(/Note for this reason/i), { target: { value: text } });
+  fireEvent.click(within(region).getByLabelText("Save note"));
 }
 
 describe("ByReasonView", () => {
@@ -48,5 +54,36 @@ describe("ByReasonView", () => {
     // After expanding, the grouped tests are shown.
     const region = screen.getByRole("region");
     expect(within(region).getByText("Test_A")).toBeInTheDocument();
+  });
+});
+
+describe("ByReasonView — inline notes", () => {
+  it("shows the reason note label when collapsed but hides the write actions", () => {
+    renderView("BR1");
+    const summary = screen.getByRole("button", { name: /FATAL element not found/i });
+
+    fireEvent.click(summary); // expand → reason-level Add note action is available
+    addReasonNote(screen.getByRole("region"), "infra note");
+
+    fireEvent.click(summary); // collapse
+    expect(summary).toHaveAttribute("aria-expanded", "false");
+    // Label stays readable in the collapsed list view…
+    expect(screen.getAllByText("infra note").length).toBeGreaterThan(0);
+    // …but no write actions are rendered while collapsed.
+    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
+  });
+
+  it("cascades an added reason note to all child test rows and clears them on delete", () => {
+    renderView("BR2");
+    const summary = screen.getByRole("button", { name: /FATAL element not found/i });
+    fireEvent.click(summary);
+    const region = screen.getByRole("region");
+
+    addReasonNote(region, "cascade-xyz");
+    // Reason chip + Test_A row chip + Test_B row chip.
+    expect(screen.getAllByText("cascade-xyz")).toHaveLength(3);
+
+    fireEvent.click(within(region).getByLabelText("Delete note"));
+    expect(screen.queryByText("cascade-xyz")).toBeNull();
   });
 });

--- a/client/src/components/__tests__/FailureCard.test.tsx
+++ b/client/src/components/__tests__/FailureCard.test.tsx
@@ -3,10 +3,13 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import FailureCard from "../FailureCard";
 import type { RecentFailureGroupedItem } from "../../types/RecentFailuresGrouped";
 
-// Mock the API so "Expand Log" never hits the network.
+// Mock the API so "Expand Log" never hits the network and notes don't fetch live.
 vi.mock("../../services/apiService", () => ({
   // Pending promise keeps the loading state visible for assertion.
   getExpandedLog: vi.fn(() => new Promise(() => {})),
+  getNotes: vi.fn(async () => []),
+  createNote: vi.fn(async () => ({ noteId: 1, testName: null, failureReason: "r", noteContent: "c", createdAt: null })),
+  deleteNote: vi.fn(async () => {}),
 }));
 
 const item: RecentFailureGroupedItem = {
@@ -64,5 +67,11 @@ describe("FailureCard", () => {
     renderCard();
     fireEvent.click(screen.getByRole("button", { name: /expand log/i }));
     expect(await screen.findByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("renders the inline notes Add control without crashing", () => {
+    renderCard();
+    // The notes area is wired through useNotes — the card must render its Add control.
+    expect(screen.getAllByRole("button", { name: /add note/i }).length).toBeGreaterThan(0);
   });
 });

--- a/client/src/components/__tests__/InlineNotes.test.tsx
+++ b/client/src/components/__tests__/InlineNotes.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import InlineNotes from "../InlineNotes";
+
+// The note store is module-level and shared across instances, so each test uses a
+// unique entityId to stay isolated.
+
+function addNote(placeholder: RegExp, text: string, scope?: HTMLElement) {
+  const root = scope ? within(scope) : screen;
+  fireEvent.click(root.getByRole("button", { name: "Add note" }));
+  fireEvent.change(root.getByPlaceholderText(placeholder), { target: { value: text } });
+  fireEvent.click(root.getByLabelText("Save note"));
+}
+
+describe("InlineNotes — visibility logic", () => {
+  it("renders Add/Edit/Delete actions in the editable (expanded) view", () => {
+    render(<InlineNotes scope="test" entityId="vis-edit" />);
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+
+    addNote(/Note for this test/i, "remember to retry");
+
+    expect(screen.getByText("remember to retry")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit note")).toBeInTheDocument();
+    expect(screen.getByLabelText("Delete note")).toBeInTheDocument();
+    // Add stays available to append more notes.
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+  });
+
+  it("read-only (collapsed) view shows labels but no write actions", () => {
+    const id = "vis-readonly";
+    // Seed a note through an editable instance...
+    const { unmount } = render(<InlineNotes scope="test" entityId={id} />);
+    addNote(/Note for this test/i, "collapsed label");
+    unmount();
+
+    // ...then the read-only view shows the chip with no Add/Edit/Delete.
+    render(<InlineNotes scope="test" entityId={id} readOnly />);
+    expect(screen.getByText("collapsed label")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
+    expect(screen.queryByLabelText("Edit note")).toBeNull();
+    expect(screen.queryByLabelText("Delete note")).toBeNull();
+  });
+
+  it("renders nothing in read-only mode when there are no notes", () => {
+    const { container } = render(<InlineNotes scope="test" entityId="empty-readonly" readOnly />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("InlineNotes — JIRA auto-linking", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("turns a JIRA ticket id into a safe new-tab link", () => {
+    render(<InlineNotes scope="test" entityId="jira-static" />);
+    addNote(/Note for this test/i, "Fixes URM-88888");
+
+    const link = screen.getByRole("link", { name: "URM-88888" });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    expect(link.getAttribute("href")).toMatch(/URM-88888$/);
+  });
+
+  it("uses the mocked VITE_JIRA_BASE_URL for link hrefs", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_JIRA_BASE_URL", "https://jira.test/browse/");
+    const { default: FreshInlineNotes } = await import("../InlineNotes");
+
+    render(<FreshInlineNotes scope="test" entityId="jira-env" />);
+    addNote(/Note for this test/i, "see URM-5 for details");
+
+    const link = screen.getByRole("link", { name: "URM-5" });
+    expect(link).toHaveAttribute("href", "https://jira.test/browse/URM-5");
+  });
+});
+
+describe("InlineNotes — cascading logic", () => {
+  it("adding a reason note propagates to all child tests; deleting removes it from all", () => {
+    const reasonId = "reason:AREA:R1";
+    const t1 = "test:AREA:Test_A";
+    const t2 = "test:AREA:Test_B";
+
+    render(
+      <>
+        <div data-testid="reason"><InlineNotes scope="reason" entityId={reasonId} cascadeTo={[t1, t2]} /></div>
+        <div data-testid="t1"><InlineNotes scope="test" entityId={t1} readOnly /></div>
+        <div data-testid="t2"><InlineNotes scope="test" entityId={t2} readOnly /></div>
+      </>,
+    );
+
+    const reason = screen.getByTestId("reason");
+    addNote(/Note for this reason/i, "shared infra issue", reason);
+
+    // Cascaded to both child tests.
+    expect(within(screen.getByTestId("t1")).getByText("shared infra issue")).toBeInTheDocument();
+    expect(within(screen.getByTestId("t2")).getByText("shared infra issue")).toBeInTheDocument();
+
+    // Delete at the reason level cascades the removal to every child test.
+    fireEvent.click(within(reason).getByLabelText("Delete note"));
+
+    expect(within(screen.getByTestId("t1")).queryByText("shared infra issue")).toBeNull();
+    expect(within(screen.getByTestId("t2")).queryByText("shared infra issue")).toBeNull();
+  });
+});

--- a/client/src/components/__tests__/InlineNotes.test.tsx
+++ b/client/src/components/__tests__/InlineNotes.test.tsx
@@ -36,8 +36,8 @@ describe("InlineNotes — visibility logic", () => {
     expect(await screen.findByText("remember to retry")).toBeInTheDocument();
     expect(screen.getByLabelText("Edit note")).toBeInTheDocument();
     expect(screen.getByLabelText("Delete note")).toBeInTheDocument();
-    // Unique (test, reason) → Add hidden once a note exists.
-    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
+    // Multiple notes allowed → Add stays available after the first note.
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
   });
 
   it("read-only (collapsed) view shows labels but no write actions", async () => {
@@ -63,6 +63,17 @@ describe("InlineNotes — backend wiring", () => {
     await addNote("shared infra issue");
     expect(await screen.findByText("shared infra issue")).toBeInTheDocument();
     expect(api.createNote).toHaveBeenCalledWith(null, "reasonA", "shared infra issue");
+  });
+
+  it("displays global (testName null) notes as read-only inherited on a specific test", async () => {
+    db = [{ noteId: 9, testName: null, failureReason: "reasonA", noteContent: "global infra", createdAt: null }];
+    render(<InlineNotes testName="Test_A" failureReason="reasonA" />);
+
+    expect(await screen.findByText("global infra")).toBeInTheDocument();
+    // Inherited globals are not editable from the test view…
+    expect(screen.queryByLabelText("Edit note")).toBeNull();
+    // …but the test still offers its own Add note.
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
   });
 
   it("DELETEs a note via its id", async () => {

--- a/client/src/components/__tests__/InlineNotes.test.tsx
+++ b/client/src/components/__tests__/InlineNotes.test.tsx
@@ -1,60 +1,86 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import InlineNotes from "../InlineNotes";
+import * as api from "../../services/apiService";
+import { __resetNotesCacheForTests } from "../../hooks/useNotes";
 
-// The note store is module-level and shared across instances, so each test uses a
-// unique entityId to stay isolated.
+// In-memory fake backend (test-file scoped, reset before each test).
+let db: Array<{ noteId: number; testName: string | null; failureReason: string; noteContent: string; createdAt: string | null }>;
+let seq: number;
 
-function addNote(placeholder: RegExp, text: string, scope?: HTMLElement) {
-  const root = scope ? within(scope) : screen;
-  fireEvent.click(root.getByRole("button", { name: "Add note" }));
-  fireEvent.change(root.getByPlaceholderText(placeholder), { target: { value: text } });
-  fireEvent.click(root.getByLabelText("Save note"));
+vi.mock("../../services/apiService", () => ({
+  getNotes: vi.fn(async () => db),
+  createNote: vi.fn(async (testName: string | null, failureReason: string, content: string) => {
+    const note = { noteId: ++seq, testName: testName ?? null, failureReason, noteContent: content, createdAt: null };
+    db.push(note);
+    return note;
+  }),
+  deleteNote: vi.fn(async (id: number) => { db = db.filter((n) => n.noteId !== id); }),
+}));
+
+beforeEach(() => { db = []; seq = 0; __resetNotesCacheForTests(); vi.clearAllMocks(); });
+afterEach(() => vi.unstubAllEnvs());
+
+async function addNote(text: string) {
+  fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+  fireEvent.change(screen.getByPlaceholderText(/Note for this/i), { target: { value: text } });
+  fireEvent.click(screen.getByLabelText("Save note"));
 }
 
 describe("InlineNotes — visibility logic", () => {
-  it("renders Add/Edit/Delete actions in the editable (expanded) view", () => {
-    render(<InlineNotes scope="test" entityId="vis-edit" />);
-    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+  it("renders Add/Edit/Delete actions in the editable (expanded) view", async () => {
+    render(<InlineNotes testName="Test_A" failureReason="reasonA" />);
 
-    addNote(/Note for this test/i, "remember to retry");
+    await addNote("remember to retry");
 
-    expect(screen.getByText("remember to retry")).toBeInTheDocument();
+    expect(await screen.findByText("remember to retry")).toBeInTheDocument();
     expect(screen.getByLabelText("Edit note")).toBeInTheDocument();
     expect(screen.getByLabelText("Delete note")).toBeInTheDocument();
-    // Add stays available to append more notes.
-    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+    // Unique (test, reason) → Add hidden once a note exists.
+    expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
   });
 
-  it("read-only (collapsed) view shows labels but no write actions", () => {
-    const id = "vis-readonly";
-    // Seed a note through an editable instance...
-    const { unmount } = render(<InlineNotes scope="test" entityId={id} />);
-    addNote(/Note for this test/i, "collapsed label");
-    unmount();
+  it("read-only (collapsed) view shows labels but no write actions", async () => {
+    db = [{ noteId: 1, testName: "Test_A", failureReason: "reasonA", noteContent: "collapsed label", createdAt: null }];
+    render(<InlineNotes testName="Test_A" failureReason="reasonA" readOnly />);
 
-    // ...then the read-only view shows the chip with no Add/Edit/Delete.
-    render(<InlineNotes scope="test" entityId={id} readOnly />);
-    expect(screen.getByText("collapsed label")).toBeInTheDocument();
+    expect(await screen.findByText("collapsed label")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add note" })).toBeNull();
     expect(screen.queryByLabelText("Edit note")).toBeNull();
     expect(screen.queryByLabelText("Delete note")).toBeNull();
   });
 
   it("renders nothing in read-only mode when there are no notes", () => {
-    const { container } = render(<InlineNotes scope="test" entityId="empty-readonly" readOnly />);
+    const { container } = render(<InlineNotes testName="Test_X" failureReason="reasonX" readOnly />);
     expect(container).toBeEmptyDOMElement();
   });
 });
 
+describe("InlineNotes — backend wiring", () => {
+  it("POSTs a general reason note with null testName", async () => {
+    render(<InlineNotes failureReason="reasonA" />); // no testName → general
+
+    await addNote("shared infra issue");
+    expect(await screen.findByText("shared infra issue")).toBeInTheDocument();
+    expect(api.createNote).toHaveBeenCalledWith(null, "reasonA", "shared infra issue");
+  });
+
+  it("DELETEs a note via its id", async () => {
+    db = [{ noteId: 7, testName: "Test_A", failureReason: "reasonA", noteContent: "to delete", createdAt: null }];
+    render(<InlineNotes testName="Test_A" failureReason="reasonA" />);
+
+    fireEvent.click(await screen.findByLabelText("Delete note"));
+    expect(api.deleteNote).toHaveBeenCalledWith(7);
+  });
+});
+
 describe("InlineNotes — JIRA auto-linking", () => {
-  afterEach(() => vi.unstubAllEnvs());
+  it("turns a JIRA ticket id into a safe new-tab link", async () => {
+    render(<InlineNotes testName="Test_A" failureReason="reasonA" />);
 
-  it("turns a JIRA ticket id into a safe new-tab link", () => {
-    render(<InlineNotes scope="test" entityId="jira-static" />);
-    addNote(/Note for this test/i, "Fixes URM-88888");
+    await addNote("Fixes URM-88888");
 
-    const link = screen.getByRole("link", { name: "URM-88888" });
+    const link = await screen.findByRole("link", { name: "URM-88888" });
     expect(link.tagName).toBe("A");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link.getAttribute("rel")).toContain("noopener");
@@ -62,43 +88,15 @@ describe("InlineNotes — JIRA auto-linking", () => {
   });
 
   it("uses the mocked VITE_JIRA_BASE_URL for link hrefs", async () => {
+    // Re-evaluate the module with the env stubbed so the base URL is picked up.
     vi.resetModules();
     vi.stubEnv("VITE_JIRA_BASE_URL", "https://jira.test/browse/");
     const { default: FreshInlineNotes } = await import("../InlineNotes");
 
-    render(<FreshInlineNotes scope="test" entityId="jira-env" />);
-    addNote(/Note for this test/i, "see URM-5 for details");
+    render(<FreshInlineNotes testName="Test_A" failureReason="reasonA" />);
+    await addNote("see URM-5 for details");
 
-    const link = screen.getByRole("link", { name: "URM-5" });
+    const link = await screen.findByRole("link", { name: "URM-5" });
     expect(link).toHaveAttribute("href", "https://jira.test/browse/URM-5");
-  });
-});
-
-describe("InlineNotes — cascading logic", () => {
-  it("adding a reason note propagates to all child tests; deleting removes it from all", () => {
-    const reasonId = "reason:AREA:R1";
-    const t1 = "test:AREA:Test_A";
-    const t2 = "test:AREA:Test_B";
-
-    render(
-      <>
-        <div data-testid="reason"><InlineNotes scope="reason" entityId={reasonId} cascadeTo={[t1, t2]} /></div>
-        <div data-testid="t1"><InlineNotes scope="test" entityId={t1} readOnly /></div>
-        <div data-testid="t2"><InlineNotes scope="test" entityId={t2} readOnly /></div>
-      </>,
-    );
-
-    const reason = screen.getByTestId("reason");
-    addNote(/Note for this reason/i, "shared infra issue", reason);
-
-    // Cascaded to both child tests.
-    expect(within(screen.getByTestId("t1")).getByText("shared infra issue")).toBeInTheDocument();
-    expect(within(screen.getByTestId("t2")).getByText("shared infra issue")).toBeInTheDocument();
-
-    // Delete at the reason level cascades the removal to every child test.
-    fireEvent.click(within(reason).getByLabelText("Delete note"));
-
-    expect(within(screen.getByTestId("t1")).queryByText("shared infra issue")).toBeNull();
-    expect(within(screen.getByTestId("t2")).queryByText("shared infra issue")).toBeNull();
-  });
+  }, 15000);
 });

--- a/client/src/components/__tests__/SearchWithHistory.test.tsx
+++ b/client/src/components/__tests__/SearchWithHistory.test.tsx
@@ -36,6 +36,28 @@ describe("SearchWithHistory", () => {
     expect(onSearch).toHaveBeenCalledWith("alpha");
   });
 
+  it("does NOT save typed text on Enter by default (Home page behaviour)", () => {
+    render(<SearchWithHistory value="my typed query" onSearch={() => {}} storageKey={KEY} placeholder="Search…" />);
+    fireEvent.keyDown(screen.getByPlaceholderText("Search…"), { key: "Enter" });
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("saves the raw typed query on Enter when saveTypedQueries is set (Recent Failures behaviour)", () => {
+    render(<SearchWithHistory value="flaky login" onSearch={() => {}} storageKey={KEY} placeholder="Search…" saveTypedQueries />);
+    fireEvent.keyDown(screen.getByPlaceholderText("Search…"), { key: "Enter" });
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["flaky login"]);
+  });
+
+  it("keeps independent history per storage key", () => {
+    const KEY_RECENT = "recent-failures-query-text-history";
+    const KEY_HOME = "dashboard-search-history";
+    render(<SearchWithHistory value="typed on recent" onSearch={() => {}} storageKey={KEY_RECENT} placeholder="Recent" saveTypedQueries />);
+    fireEvent.keyDown(screen.getByPlaceholderText("Recent"), { key: "Enter" });
+
+    expect(JSON.parse(localStorage.getItem(KEY_RECENT)!)).toEqual(["typed on recent"]);
+    expect(localStorage.getItem(KEY_HOME)).toBeNull(); // Home's history is untouched
+  });
+
   it("removes a single history item via its X button without closing the dropdown", () => {
     seed(["alpha", "beta"]);
     render(<SearchWithHistory value="" onSearch={() => {}} storageKey={KEY} placeholder="Search…" />);

--- a/client/src/components/__tests__/failureHelpers.test.ts
+++ b/client/src/components/__tests__/failureHelpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration, formatDateOnly, formatDateTime, extractFatalLine } from "../failureHelpers";
+
+describe("formatDuration", () => {
+  it("formats an explicit duration in seconds", () => {
+    expect(formatDuration({ duration: 135 })).toBe("2m 15s");
+  });
+
+  it("formats sub-minute durations without minutes", () => {
+    expect(formatDuration({ duration: 42 })).toBe("42s");
+  });
+
+  it("treats large explicit values as milliseconds", () => {
+    expect(formatDuration({ duration: 135000 })).toBe("2m 15s");
+  });
+
+  it("reads alternate key names (totalRunTime-style via runTime)", () => {
+    expect(formatDuration({ runTime: 90 })).toBe("1m 30s");
+  });
+
+  it("calculates the delta between start/end timestamps (unix seconds)", () => {
+    expect(formatDuration({ startTime: 1_000, endTime: 1_135 })).toBe("2m 15s");
+  });
+
+  it("calculates the delta between start/end ISO timestamps", () => {
+    expect(formatDuration({ startTime: "2026-06-22T10:00:00Z", endTime: "2026-06-22T10:01:05Z" })).toBe("1m 5s");
+  });
+
+  it("returns the graceful 'Timeout' fallback for impossible (> 2h) durations, never '1489m'", () => {
+    const out = formatDuration({ duration: 1489 * 60 + 44 }); // the reported outlier
+    expect(out).toBe("Timeout");
+    expect(out).not.toContain("1489");
+  });
+
+  it("returns empty string when no usable duration data exists", () => {
+    expect(formatDuration({ server: "QAC01" })).toBe("");
+    expect(formatDuration(null)).toBe("");
+  });
+});
+
+describe("formatDateOnly / formatDateTime", () => {
+  it("formats date only as DD/MM/YYYY (no time)", () => {
+    expect(formatDateOnly("2026-06-14T10:30:00")).toBe("14/06/2026");
+  });
+
+  it("appends HH:mm only when the source includes a time", () => {
+    expect(formatDateTime("2026-06-14T10:30:00")).toBe("14/06/2026 10:30");
+    expect(formatDateTime("2026-06-14")).toBe("14/06/2026");
+  });
+});
+
+describe("extractFatalLine", () => {
+  it("returns ONLY the line containing FATAL from a multi-line log", () => {
+    const log = [
+      "INFO starting test",
+      "DEBUG clicking button",
+      "FATAL element not found: #submit",
+      "INFO teardown",
+    ].join("\n");
+    expect(extractFatalLine(log)).toBe("FATAL element not found: #submit");
+  });
+
+  it("falls back to the first non-empty line when no FATAL exists", () => {
+    const log = ["", "  Timeout waiting for selector", "DEBUG more"].join("\n");
+    expect(extractFatalLine(log)).toBe("Timeout waiting for selector");
+  });
+
+  it("returns empty string for empty/missing text", () => {
+    expect(extractFatalLine("")).toBe("");
+    expect(extractFatalLine(null)).toBe("");
+  });
+});

--- a/client/src/components/failureHelpers.tsx
+++ b/client/src/components/failureHelpers.tsx
@@ -2,9 +2,16 @@
 
 export const WINDOW_DAYS = 10;
 
+// Error markers we highlight / anchor on — includes JVM OOM crashes.
+const ERROR_MARKERS = ["FATAL", "OUTOFMEMORYERROR", "JAVA HEAP SPACE"];
+function isErrorLine(line: string): boolean {
+  const u = line.toUpperCase();
+  return ERROR_MARKERS.some((m) => u.includes(m));
+}
+
 export function renderLogLines(lines: string[]) {
   return lines.map((line, i) => {
-    const isFatal = line.toUpperCase().includes("FATAL");
+    const isFatal = isErrorLine(line);
     return (
       <div
         key={i}
@@ -28,7 +35,7 @@ export function truncateLogToTestScope(logText: string, testName: string): strin
   const lines = logText.split(/\r?\n/).filter(l => l.trim() !== "");
   let fatalIdx = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i].toUpperCase().includes("FATAL")) { fatalIdx = i; break; }
+    if (isErrorLine(lines[i])) { fatalIdx = i; break; }
   }
   if (fatalIdx === -1) return lines.slice(Math.max(0, lines.length - 40));
   const nameLower = testName.toLowerCase();
@@ -55,8 +62,86 @@ export function extractFatalPreview(text: string): string[] {
   const lines = text.split(/\r?\n/);
   let fatalIdx = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i].toUpperCase().includes("FATAL")) { fatalIdx = i; break; }
+    if (isErrorLine(lines[i])) { fatalIdx = i; break; }
   }
   if (fatalIdx === -1) return lines.slice(Math.max(0, lines.length - 4)).filter(l => l.trim() !== "");
   return lines.slice(Math.max(0, fatalIdx - 3), fatalIdx + 1).filter(l => l.trim() !== "");
+}
+
+/** Returns only the line containing FATAL; falls back to the first non-empty line. */
+export function extractFatalLine(text: string | null | undefined): string {
+  if (!text) return "";
+  const lines = text.split(/\r?\n/);
+  const fatal = lines.find((l) => l.includes("FATAL"));
+  if (fatal) return fatal.trim();
+  const firstNonEmpty = lines.find((l) => l.trim() !== "");
+  return (firstNonEmpty ?? "").trim();
+}
+
+// ─── Date / time / duration formatting ────────────────────────────────────────
+
+function hasTimeComponent(value: string): boolean {
+  return /[T ]\d{2}:\d{2}/.test(value);
+}
+
+/** Formats a date string as DD/MM/YYYY, appending HH:mm when the source has a time. */
+export function formatDateTime(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return value;
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  if (!hasTimeComponent(value)) return `${dd}/${mm}/${yyyy}`;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+}
+
+/** Formats a date string as DD/MM/YYYY only (never a time component). */
+export function formatDateOnly(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return value;
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+function toMs(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && isFinite(value)) return value < 1e12 ? value * 1000 : value; // seconds vs ms
+  const d = new Date(value as string);
+  return isNaN(d.getTime()) ? null : d.getTime();
+}
+
+// A single real test run shouldn't exceed ~2h; anything beyond is a corrupt/frozen
+// row or a fallback-math artifact (e.g. a null timestamp read as the Unix epoch).
+const MAX_RUNTIME_SECONDS = 120 * 60;
+
+/**
+ * Computes a runtime label like `2m 15s` / `15s`. Prefers an explicit duration
+ * (`duration`/`runTime`/`runtime`, seconds or ms when large); otherwise derives it
+ * from start/end timestamps under any common key variant.
+ * Returns "" when nothing usable is available, or "Timeout" for impossible
+ * (> 2h) values so an outlier never renders a distorted number.
+ */
+export function formatDuration(input: Record<string, any> | null | undefined): string {
+  if (!input || typeof input !== "object") return "";
+
+  let seconds: number | null = null;
+  const explicit = input.duration ?? input.runTime ?? input.runtime ?? input.durationMs ?? input.elapsed;
+  if (typeof explicit === "number" && isFinite(explicit) && explicit >= 0) {
+    seconds = explicit > 100000 ? Math.round(explicit / 1000) : Math.round(explicit);
+  } else {
+    const start = toMs(input.startTime ?? input.startedAt ?? input.start_time ?? input.startTimeUnix ?? input.startingTimeUnix);
+    const end = toMs(input.endTime ?? input.endedAt ?? input.end_time ?? input.endTimeUnix ?? input.endingTimeUnix);
+    if (start != null && end != null && end >= start) seconds = Math.round((end - start) / 1000);
+  }
+  if (seconds == null) return "";
+  // Sanity guard: clamp impossible runtimes instead of rendering e.g. "1489m 44s".
+  if (seconds > MAX_RUNTIME_SECONDS) return "Timeout";
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }

--- a/client/src/hooks/__tests__/useNotes.test.ts
+++ b/client/src/hooks/__tests__/useNotes.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { getNotesForItem } from "../useNotes";
+import type { FailureNote } from "../../services/apiService";
+
+const note = (over: Partial<FailureNote>): FailureNote => ({
+  noteId: Math.floor(Math.random() * 1e6),
+  testName: null,
+  failureReason: "FATAL element not found",
+  noteContent: "x",
+  createdAt: null,
+  ...over,
+});
+
+describe("getNotesForItem", () => {
+  it("merges a global (testName null) note with a test sharing the same reason", () => {
+    const all = [
+      note({ noteId: 1, testName: null, failureReason: "FATAL element not found", noteContent: "global" }),
+      note({ noteId: 2, testName: "Test_A", failureReason: "FATAL element not found", noteContent: "private A" }),
+    ];
+
+    const result = getNotesForItem(all, "Test_A", "FATAL element not found");
+    expect(result.map((n) => n.noteId).sort()).toEqual([1, 2]);
+  });
+
+  it("matches permissively across whitespace / case / punctuation differences", () => {
+    const all = [note({ noteId: 1, testName: null, failureReason: "FATAL element not found" })];
+
+    // Same reason, but reformatted by a different endpoint.
+    const result = getNotesForItem(all, "Test_A", "  FATAL: Element  Not Found!! ");
+    expect(result.map((n) => n.noteId)).toEqual([1]);
+  });
+
+  it("matches when one reason string contains the other", () => {
+    const all = [note({ noteId: 1, testName: null, failureReason: "FATAL element not found" })];
+
+    const longer = "FATAL element not found at line 42 in module X";
+    expect(getNotesForItem(all, "Test_A", longer).map((n) => n.noteId)).toEqual([1]);
+  });
+
+  it("does not leak a private note onto a different test", () => {
+    const all = [note({ noteId: 2, testName: "Test_A", failureReason: "FATAL element not found", noteContent: "private A" })];
+
+    expect(getNotesForItem(all, "Test_B", "FATAL element not found")).toEqual([]);
+  });
+
+  it("does not include global notes for a different reason", () => {
+    const all = [note({ noteId: 1, testName: null, failureReason: "Timeout waiting for selector" })];
+
+    expect(getNotesForItem(all, "Test_A", "FATAL element not found")).toEqual([]);
+  });
+
+  it("treats empty/whitespace testName as a global lookup", () => {
+    const all = [
+      note({ noteId: 1, testName: null, failureReason: "FATAL element not found", noteContent: "global" }),
+      note({ noteId: 2, testName: "Test_A", failureReason: "FATAL element not found" }),
+    ];
+
+    // Reason-level (general) view: only global notes, never another test's private note.
+    const result = getNotesForItem(all, "   ", "FATAL element not found");
+    expect(result.map((n) => n.noteId)).toEqual([1]);
+  });
+});

--- a/client/src/hooks/useNotes.ts
+++ b/client/src/hooks/useNotes.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { getNotes, createNote, deleteNote, type FailureNote } from "../services/apiService";
+
+
+let notes: FailureNote[] = [];
+let loaded = false;
+let loading = false;
+const listeners = new Set<() => void>();
+
+const emit = () => listeners.forEach((l) => l());
+const subscribe = (cb: () => void) => { listeners.add(cb); return () => { listeners.delete(cb); }; };
+
+// Dedupe by noteId so an optimistic add that races the initial load can't double.
+const byId = (arr: FailureNote[]): FailureNote[] =>
+  Array.from(new Map(arr.map((n) => [n.noteId, n])).values());
+
+async function ensureLoaded() {
+  if (loaded || loading) return;
+  loading = true;
+  try {
+    const fetched = await getNotes();
+    notes = byId([...fetched, ...notes]);
+    loaded = true;
+  } catch (e) {
+    console.error("Failed to load notes:", e);
+  } finally {
+    loading = false;
+    emit();
+  }
+}
+
+/** Test-only: clears the module-level cache so each test starts isolated. */
+export function __resetNotesCacheForTests() {
+  notes = [];
+  loaded = false;
+  loading = false;
+  emit();
+}
+
+const sameTest = (a: string | null, b: string | null) => (a ?? null) === (b ?? null);
+
+/** Notes matching a given (testName, failureReason) pair. testName null = general reason note. */
+export function selectNotes(all: FailureNote[], testName: string | null, failureReason: string): FailureNote[] {
+  return all.filter((n) => sameTest(n.testName, testName) && n.failureReason === failureReason);
+}
+
+export function useNotes() {
+  const all = useSyncExternalStore(subscribe, () => notes);
+  useEffect(() => { ensureLoaded(); }, []);
+
+  const add = useCallback(async (testName: string | null, failureReason: string, content: string) => {
+    try {
+      const created = await createNote(testName, failureReason, content);
+      notes = byId([created, ...notes]);
+      emit();
+    } catch (e) {
+      console.error("Failed to add note:", e);
+    }
+  }, []);
+
+  const remove = useCallback(async (id: number) => {
+    try {
+      await deleteNote(id);
+      notes = notes.filter((n) => n.noteId !== id);
+      emit();
+    } catch (e) {
+      console.error("Failed to delete note:", e);
+    }
+  }, []);
+
+  return { notes: all, add, remove };
+}

--- a/client/src/hooks/useNotes.ts
+++ b/client/src/hooks/useNotes.ts
@@ -39,14 +39,45 @@ export function __resetNotesCacheForTests() {
 
 const sameTest = (a: string | null, b: string | null) => (a ?? null) === (b ?? null);
 
+// FAILURE_REASON column is VARCHAR2(1000); normalize the key the same way writes do.
+const MAX_REASON_LEN = 1000;
+const normTest = (t: string | null | undefined) => (typeof t === "string" && t.trim() !== "" ? t.trim() : null);
+// Permissive key for cross-tab matching: strip ALL non-alphanumerics + lowercase.
+const reasonKey = (r: string | null | undefined) => (r ?? "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, MAX_REASON_LEN);
+
 /** Notes matching a given (testName, failureReason) pair. testName null = general reason note. */
 export function selectNotes(all: FailureNote[], testName: string | null, failureReason: string): FailureNote[] {
   return all.filter((n) => sameTest(n.testName, testName) && n.failureReason === failureReason);
 }
 
+/**
+ * Relational getter: returns BOTH the item's private notes AND the global
+ * (testName null) notes for the same failure reason. Used by every test row /
+ * reason block so global notes cascade universally.
+ */
+export function getNotesForItem(all: FailureNote[], testName: string | null | undefined, failureReason: string): FailureNote[] {
+  const tn = normTest(testName);
+  const target = reasonKey(failureReason);
+  // Permissive match: equal OR either side contains the other (endpoints format
+  // the same reason differently across tabs).
+  const reasonMatches = (other: string) => {
+    const nk = reasonKey(other);
+    if (!nk || !target) return nk === target;
+    return nk === target || nk.includes(target) || target.includes(nk);
+  };
+  return all.filter(
+    (n) => (n.testName === tn || n.testName === null) && reasonMatches(n.failureReason)
+  );
+}
+
 export function useNotes() {
   const all = useSyncExternalStore(subscribe, () => notes);
   useEffect(() => { ensureLoaded(); }, []);
+
+  const notesForItem = useCallback(
+    (testName: string | null | undefined, failureReason: string) => getNotesForItem(all, testName, failureReason),
+    [all]
+  );
 
   const add = useCallback(async (testName: string | null, failureReason: string, content: string) => {
     try {
@@ -68,5 +99,5 @@ export function useNotes() {
     }
   }, []);
 
-  return { notes: all, add, remove };
+  return { notes: all, add, remove, notesForItem };
 }

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
-  Box, Typography, Button,
+  Box, Typography, Button, IconButton, Tooltip,
   Collapse, ToggleButtonGroup, ToggleButton, Paper, Skeleton, Alert,
   Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
@@ -10,7 +10,8 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import SearchInput from "../components/SearchInput";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import SearchWithHistory from "../components/SearchWithHistory";
 import ThemeToggle from "../components/ThemeToggle";
 import { useTestRailIds } from "../hooks/useTestRailIds";
 import FailureCard, { latestFailedToGroupedItem } from "../components/FailureCard";
@@ -133,9 +134,19 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     }}
                   >
                     <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "#ef4444", flexShrink: 0 }} />
-                    <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
+                    <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", minWidth: 0, flexShrink: 1, maxWidth: "55%", wordBreak: "break-all" }}>
                       {test.testName}
                     </Typography>
+                    <Tooltip title="Copy test name">
+                      <IconButton
+                        size="small"
+                        aria-label="Copy test name"
+                        onClick={(e) => { e.stopPropagation(); navigator.clipboard?.writeText(test.testName); }}
+                        sx={{ flexShrink: 0, p: 0.25, ml: 0.25, color: "text.disabled", "&:hover": { color: "text.secondary" } }}
+                      >
+                        <ContentCopyIcon sx={{ fontSize: 14 }} />
+                      </IconButton>
+                    </Tooltip>
                     {/* List view: notes + Add control on the far right of the row. */}
                     {!isOpen && (
                       <Box sx={{ ml: "auto", mr: 1, display: "flex", minWidth: 0, maxWidth: "55%", overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
@@ -443,9 +454,12 @@ const RecentFailuresPage: React.FC = () => {
           <ToggleButton value={3}>By Reason</ToggleButton>
         </ToggleButtonGroup>
 
-        <SearchInput
+        <SearchWithHistory
           value={search}
-          onChange={setSearch}
+          onSearch={setSearch}
+          storageKey="recent-failures-query-text-history"
+          placeholder="Search failures…"
+          saveTypedQueries
           sx={{ width: 280 }}
         />
       </Box>

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -3,10 +3,8 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Box, Typography, Button,
   Collapse, ToggleButtonGroup, ToggleButton, Paper, Skeleton, Alert,
-  Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -15,8 +13,7 @@ import ThemeToggle from "../components/ThemeToggle";
 import { useTestRailIds } from "../hooks/useTestRailIds";
 import FailureCard, { latestFailedToGroupedItem } from "../components/FailureCard";
 import FailureRowList from "../components/FailureRowList";
-import TestNoteButton from "../components/TestNoteButton";
-import TestNoteDisplay from "../components/TestNoteDisplay";
+import InlineNotes from "../components/InlineNotes";
 import ByReasonView from "../components/ByReasonView";
 import ImageModal from "../components/ImageModal";
 import LogModal from "../components/LogModal";
@@ -28,22 +25,6 @@ import type { LatestFailedTestsResponse } from "../types/LatestFailed";
 import type { AreaFailuresByReasonResponse } from "../types/FailuresByReason";
 
 const LIMIT = 200;
-
-// Shared styling for the collapsible group accordions (By Server / By Job).
-const accordionSx = {
-  bgcolor: "background.paper",
-  border: 1,
-  borderColor: "divider",
-  borderRadius: 2,
-  overflow: "hidden",
-  "&:before": { display: "none" },
-  boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
-} as const;
-
-const accordionSummarySx = {
-  bgcolor: "#1e293b",
-  "& .MuiAccordionSummary-content": { alignItems: "center", gap: 1.5, my: 1.25, minWidth: 0 },
-} as const;
 
 function buildTestHistoryPath(areaName: string, testName: string, env: EnvFilter): string {
   return `/area/${encodeURIComponent(areaName)}/test/${encodeURIComponent(testName)}/history?env=${env}`;
@@ -95,17 +76,24 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
       {filteredServers.map((serverGroup) => (
-        <Accordion key={serverGroup.server} disableGutters sx={accordionSx}>
-          <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />} sx={accordionSummarySx}>
+        <Box key={serverGroup.server}>
+          {/* Server header */}
+          <Box sx={{
+            display: "flex", alignItems: "center", gap: 1.5,
+            px: 2.25, py: 1.5,
+            bgcolor: "#1e293b",
+            borderRadius: "8px 8px 0 0",
+            borderBottom: "3px solid #ef4444",
+          }}>
             <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🖥️</Typography>
-            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
+            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em" }}>
               {serverGroup.server}
             </Typography>
-            <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
+            <Box component="span" sx={{ ml: "auto", bgcolor: "#ef4444", color: "#fff", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
               {serverGroup.tests.length} {serverGroup.tests.length === 1 ? "test" : "tests"}
             </Box>
-          </AccordionSummary>
-          <AccordionDetails sx={{ p: 0 }}>
+          </Box>
+
           {/* Test list */}
           <Paper variant="outlined" sx={{ borderTop: "none", borderRadius: "0 0 8px 8px", overflow: "hidden" }}>
             {serverGroup.tests.map((test, idx) => {
@@ -132,7 +120,16 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                       {test.testName}
                     </Typography>
-                    <TestNoteButton areaName={areaName} testName={test.testName} stopPropagation />
+                    {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
+                    {!isOpen && (
+                      <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+                        <InlineNotes
+                          scope="test"
+                          entityId={`test:${areaName ?? ""}:${test.testName}`}
+                          readOnly
+                        />
+                      </Box>
+                    )}
                     {trUrl && (
                       <Button
                         size="small"
@@ -186,10 +183,6 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     }} />
                   </Box>
 
-                  <Box sx={{ px: 2, "&:not(:empty)": { pb: 1.25 } }}>
-                    <TestNoteDisplay areaName={areaName} testName={test.testName} />
-                  </Box>
-
                   <Collapse in={isOpen} unmountOnExit>
                     <Box sx={{
                       p: "16px 16px 20px",
@@ -212,8 +205,7 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
               );
             })}
           </Paper>
-          </AccordionDetails>
-        </Accordion>
+        </Box>
       ))}
     </Box>
   );
@@ -383,7 +375,7 @@ const RecentFailuresPage: React.FC = () => {
         {activeTab === 1 && latestData && (
           <Box sx={{ bgcolor: "#fef2f2", border: "1px solid #fecaca", borderRadius: 2.5, px: 2.25, py: 0.75, textAlign: "center" }}>
             <Typography sx={{ fontSize: 20, fontWeight: 800, color: "#dc2626" }}>{latestData.totalCount}</Typography>
-            <Typography sx={{ fontSize: 11, color: "#ef4444" }}>failed tests</Typography>
+            <Typography sx={{ fontSize: 11, color: "#ef4444" }}>broken now</Typography>
           </Box>
         )}
         {activeTab === 2 && data && (
@@ -516,27 +508,33 @@ const RecentFailuresPage: React.FC = () => {
             {!loading && !error && jobGroups.length > 0 && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
                 {jobGroups.map(group => (
-                  <Accordion key={group.job} disableGutters sx={accordionSx}>
-                    <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />} sx={accordionSummarySx}>
+                  <Box key={group.job}>
+                    {/* Job header */}
+                    <Box sx={{
+                      display: "flex", alignItems: "center", gap: 1.5,
+                      px: 2.25, py: 1.5,
+                      bgcolor: "#1e293b",
+                      borderRadius: "8px 8px 0 0",
+                      borderBottom: "3px solid #475569",
+                    }}>
                       <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🛠️</Typography>
-                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
+                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", wordBreak: "break-all" }}>
                         {group.job}
                       </Typography>
-                      <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
+                      <Box component="span" sx={{ ml: "auto", bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700, flexShrink: 0 }}>
                         {group.items.length} {group.items.length === 1 ? "test" : "tests"}
                       </Box>
-                    </AccordionSummary>
-                    <AccordionDetails sx={{ p: 0 }}>
-                      <FailureRowList
-                        items={group.items}
-                        onImageClick={setImageSrc}
-                        onExpandLog={(lines, testName, label) => setLogModal({ lines, testName, label })}
-                        onOpenHistory={openTestHistory}
-                        testRailUrlFor={testRailUrlFor}
-                        areaName={areaName}
-                      />
-                    </AccordionDetails>
-                  </Accordion>
+                    </Box>
+                    {/* Compact rows (same look as List View) */}
+                    <FailureRowList
+                      items={group.items}
+                      onImageClick={setImageSrc}
+                      onExpandLog={(lines, testName, label) => setLogModal({ lines, testName, label })}
+                      onOpenHistory={openTestHistory}
+                      testRailUrlFor={testRailUrlFor}
+                      areaName={areaName}
+                    />
+                  </Box>
                 ))}
               </Box>
             )}

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -140,8 +140,8 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     {!isOpen && (
                       <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                         <InlineNotes
-                          scope="test"
-                          entityId={`test:${areaName ?? ""}:${test.testName}`}
+                          testName={test.testName}
+                          failureReason={test.failureText ?? "General"}
                           readOnly
                         />
                       </Box>

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -3,8 +3,10 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Box, Typography, Button,
   Collapse, ToggleButtonGroup, ToggleButton, Paper, Skeleton, Alert,
+  Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import HistoryIcon from "@mui/icons-material/History";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -29,6 +31,24 @@ const LIMIT = 200;
 function buildTestHistoryPath(areaName: string, testName: string, env: EnvFilter): string {
   return `/area/${encodeURIComponent(areaName)}/test/${encodeURIComponent(testName)}/history?env=${env}`;
 }
+
+// Shared styling for the dark group accordions (By Server / By Job).
+const groupAccordionSx = {
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  borderRadius: 2,
+  overflow: "hidden",
+  "&:before": { display: "none" },
+  boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+} as const;
+
+// minWidth:0 lets the title shrink; the expandIcon then always stays visible.
+const groupSummarySx = {
+  bgcolor: "#1e293b",
+  "& .MuiAccordionSummary-content": { alignItems: "center", gap: 1.5, my: 1.25, minWidth: 0 },
+  "& .MuiAccordionSummary-expandIconWrapper": { color: "#94a3b8", flexShrink: 0 },
+} as const;
 
 // ─── Latest Failed View ───────────────────────────────────────────────────────
 
@@ -76,24 +96,20 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
       {filteredServers.map((serverGroup) => (
-        <Box key={serverGroup.server}>
-          {/* Server header */}
-          <Box sx={{
-            display: "flex", alignItems: "center", gap: 1.5,
-            px: 2.25, py: 1.5,
-            bgcolor: "#1e293b",
-            borderRadius: "8px 8px 0 0",
-            borderBottom: "3px solid #ef4444",
-          }}>
-            <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🖥️</Typography>
-            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em" }}>
+        <Accordion key={serverGroup.server} disableGutters sx={groupAccordionSx}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />}
+            sx={{ ...groupSummarySx, borderBottom: "3px solid #ef4444" }}
+          >
+            <Typography sx={{ fontSize: 18, lineHeight: 1, flexShrink: 0 }}>🖥️</Typography>
+            <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.05em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
               {serverGroup.server}
             </Typography>
-            <Box component="span" sx={{ ml: "auto", bgcolor: "#ef4444", color: "#fff", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
+            <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#ef4444", color: "#fff", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
               {serverGroup.tests.length} {serverGroup.tests.length === 1 ? "test" : "tests"}
             </Box>
-          </Box>
-
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
           {/* Test list */}
           <Paper variant="outlined" sx={{ borderTop: "none", borderRadius: "0 0 8px 8px", overflow: "hidden" }}>
             {serverGroup.tests.map((test, idx) => {
@@ -122,7 +138,7 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     </Typography>
                     {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
                     {!isOpen && (
-                      <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+                      <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                         <InlineNotes
                           scope="test"
                           entityId={`test:${areaName ?? ""}:${test.testName}`}
@@ -148,6 +164,7 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                           px: "10px",
                           minHeight: 0,
                           lineHeight: 1.4,
+                          flexShrink: 0,
                           "&:hover": { borderColor: "#94a3b8", bgcolor: "#fff", color: "#0f172a" },
                         }}
                       >
@@ -171,6 +188,7 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                         px: "10px",
                         minHeight: 0,
                         lineHeight: 1.4,
+                        flexShrink: 0,
                         "&:hover": { borderColor: "#94a3b8", bgcolor: "#fff", color: "#0f172a" },
                       }}
                     >
@@ -205,7 +223,8 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
               );
             })}
           </Paper>
-        </Box>
+          </AccordionDetails>
+        </Accordion>
       ))}
     </Box>
   );
@@ -508,23 +527,20 @@ const RecentFailuresPage: React.FC = () => {
             {!loading && !error && jobGroups.length > 0 && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 3.5 }}>
                 {jobGroups.map(group => (
-                  <Box key={group.job}>
-                    {/* Job header */}
-                    <Box sx={{
-                      display: "flex", alignItems: "center", gap: 1.5,
-                      px: 2.25, py: 1.5,
-                      bgcolor: "#1e293b",
-                      borderRadius: "8px 8px 0 0",
-                      borderBottom: "3px solid #475569",
-                    }}>
-                      <Typography sx={{ fontSize: 18, lineHeight: 1 }}>🛠️</Typography>
-                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", wordBreak: "break-all" }}>
+                  <Accordion key={group.job} disableGutters sx={groupAccordionSx}>
+                    <AccordionSummary
+                      expandIcon={<ExpandMoreIcon sx={{ color: "#94a3b8" }} />}
+                      sx={{ ...groupSummarySx, borderBottom: "3px solid #475569" }}
+                    >
+                      <Typography sx={{ fontSize: 18, lineHeight: 1, flexShrink: 0 }}>🛠️</Typography>
+                      <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 15, fontWeight: 800, color: "#f1f5f9", letterSpacing: "0.03em", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                         {group.job}
                       </Typography>
-                      <Box component="span" sx={{ ml: "auto", bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700, flexShrink: 0 }}>
+                      <Box component="span" sx={{ ml: "auto", flexShrink: 0, bgcolor: "#475569", color: "#f1f5f9", borderRadius: 20, px: 1.5, py: "3px", fontSize: 12, fontWeight: 700 }}>
                         {group.items.length} {group.items.length === 1 ? "test" : "tests"}
                       </Box>
-                    </Box>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 0 }}>
                     {/* Compact rows (same look as List View) */}
                     <FailureRowList
                       items={group.items}
@@ -534,7 +550,8 @@ const RecentFailuresPage: React.FC = () => {
                       testRailUrlFor={testRailUrlFor}
                       areaName={areaName}
                     />
-                  </Box>
+                    </AccordionDetails>
+                  </Accordion>
                 ))}
               </Box>
             )}

--- a/client/src/pages/Recentfailurespage.tsx
+++ b/client/src/pages/Recentfailurespage.tsx
@@ -136,13 +136,13 @@ const LatestFailedView: React.FC<LatestFailedViewProps> = ({ data, search, onIma
                     <Typography sx={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", fontSize: 13, color: "text.primary", flex: 1, minWidth: 0, wordBreak: "break-all" }}>
                       {test.testName}
                     </Typography>
-                    {/* Collapsed list view: read-only note chips, flush right next to the actions. */}
+                    {/* List view: notes + Add control on the far right of the row. */}
                     {!isOpen && (
-                      <Box sx={{ ml: "auto", display: "flex", minWidth: 0, maxWidth: "45%", flexShrink: 1, overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
+                      <Box sx={{ ml: "auto", mr: 1, display: "flex", minWidth: 0, maxWidth: "55%", overflow: "hidden" }} onClick={(e) => e.stopPropagation()}>
                         <InlineNotes
                           testName={test.testName}
                           failureReason={test.failureText ?? "General"}
-                          readOnly
+                          isListView
                         />
                       </Box>
                     )}

--- a/client/src/pages/TestHistoryPage.tsx
+++ b/client/src/pages/TestHistoryPage.tsx
@@ -8,11 +8,7 @@ import { useTestRailIds } from "../hooks/useTestRailIds";
 import ThemeToggle from "../components/ThemeToggle";
 import type { TestHistoryResponse, TestHistoryRow } from "../types/TestHistory";
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
-
-function dateOnly(value: string | null | undefined): string | null {
-    if (!value) return null;
-    return value.split("T")[0].split(" ")[0];
-}
+import { formatDateOnly, extractFatalLine } from "../components/failureHelpers";
 
 const TestHistoryPage: React.FC = () => {
     const { areaName, testName } = useParams<{ areaName: string; testName: string }>();
@@ -155,10 +151,12 @@ const TestHistoryPage: React.FC = () => {
                                             <TableBody>
                                                 {rows.map((r: TestHistoryRow, i: number) => (
                                                     <TableRow key={i} sx={{ '&:last-child td': { borderBottom: 0 } }}>
-                                                        <TableCell sx={{ fontSize: 13 }}>{dateOnly(r.testedOn) ?? "-"}</TableCell>
+                                                        <TableCell sx={{ fontSize: 13, whiteSpace: "nowrap" }}>
+                                                            {formatDateOnly(r.testedOn) ?? "-"}
+                                                        </TableCell>
                                                         <TableCell align="center">{r.passed ? <Box sx={{ color: "#2e7d32", fontWeight: 700 }}>PASS</Box> : <Box sx={{ color: "#c62828", fontWeight: 700 }}>FAIL</Box>}</TableCell>
                                                         <TableCell sx={{ fontSize: 12 }}>{r.almaVersion ?? "-"}</TableCell>
-                                                        <TableCell sx={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11 }}>{r.failureText ? r.failureText.slice(0, 350) : "-"}</TableCell>
+                                                        <TableCell sx={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, whiteSpace: "pre-wrap", wordBreak: "break-word", maxWidth: 600 }}>{r.failureText ? extractFatalLine(r.failureText) : "-"}</TableCell>
                                                     </TableRow>
                                                 ))}
                                             </TableBody>

--- a/client/src/pages/__tests__/TestHistoryPage.test.tsx
+++ b/client/src/pages/__tests__/TestHistoryPage.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import TestHistoryPage from "../TestHistoryPage";
+
+vi.mock("../../services/apiService", () => ({
+  getAreaTestRailIds: vi.fn(async () => ({ areaName: "LOD", env: "qa", baseUrl: "", ids: {} })),
+  getTestHistory: vi.fn(async () => ({
+    area: "LOD",
+    testName: "MyTest",
+    env: "qa",
+    rows: [
+      {
+        testedOn: "2026-06-10T10:00:00",
+        endingTimeUnix: null,
+        passed: false,
+        server: "QAC01",
+        buildNumber: 1,
+        almaVersion: "v1",
+        failureText: "INFO start\nDEBUG clicking button\nFATAL element not found: #submit\nINFO teardown",
+        logLink: null,
+        screenshotLink: null,
+      },
+      {
+        testedOn: "2026-06-09T10:00:00",
+        endingTimeUnix: null,
+        passed: false,
+        server: "QAC01",
+        buildNumber: 1,
+        almaVersion: "v1",
+        failureText: "Timeout waiting for selector\nDEBUG retry attempt",
+        logLink: null,
+        screenshotLink: null,
+      },
+    ],
+  })),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/area/LOD/test/MyTest/history?env=qa"]}>
+      <Routes>
+        <Route path="/area/:areaName/test/:testName/history" element={<TestHistoryPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("TestHistoryPage — log extraction", () => {
+  it("shows ONLY the FATAL line from a multi-line failure log", async () => {
+    renderPage();
+    expect(await screen.findByText("FATAL element not found: #submit")).toBeInTheDocument();
+    // The surrounding non-FATAL lines must not be rendered.
+    expect(screen.queryByText(/DEBUG clicking button/)).toBeNull();
+    expect(screen.queryByText(/INFO teardown/)).toBeNull();
+  });
+
+  it("falls back to the first line when no FATAL is present", async () => {
+    renderPage();
+    expect(await screen.findByText("Timeout waiting for selector")).toBeInTheDocument();
+    expect(screen.queryByText(/DEBUG retry attempt/)).toBeNull();
+  });
+});

--- a/client/src/services/apiService.ts
+++ b/client/src/services/apiService.ts
@@ -226,3 +226,40 @@ export const getTestHistory = async (
   const response = await fetch(url);
   return handleResponse(response);
 };
+
+// ─── Failure notes (FAILURE_NOTES table) ──────────────────────────────────────
+
+export type FailureNote = {
+  noteId: number;
+  testName: string | null;
+  failureReason: string;
+  noteContent: string;
+  createdAt: string | null;
+};
+
+export const getNotes = async (): Promise<FailureNote[]> => {
+  const response = await fetch(`${API_BASE_URL}/notes`);
+  return handleResponse<FailureNote[]>(response);
+};
+
+export const createNote = async (
+  testName: string | null,
+  failureReason: string,
+  content: string
+): Promise<FailureNote> => {
+  const response = await fetch(`${API_BASE_URL}/notes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ testName, failureReason, content }),
+  });
+  const data = await handleResponse<Omit<FailureNote, "createdAt">>(response);
+  return { ...data, createdAt: null };
+};
+
+export const deleteNote = async (id: number): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/notes/${id}`, { method: "DELETE" });
+  if (!response.ok && response.status !== 204) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+  }
+};

--- a/client/src/types/LatestFailed.ts
+++ b/client/src/types/LatestFailed.ts
@@ -7,6 +7,7 @@ export type LatestFailedTestItem = {
   screenshotLink: string | null;
   almaVersion: string | null;
   buildNumber: number | null;
+  duration?: number | null;
 };
 
 export type LatestFailedByServer = {

--- a/client/src/types/RecentFailuresGrouped.ts
+++ b/client/src/types/RecentFailuresGrouped.ts
@@ -17,6 +17,8 @@ export type RecentFailureGroupedItem = {
     buildNumber: number | null;
     logLink: string | null;
     screenshotLink: string | null;
+    /** TOTALRUNTIME from Oracle — consumed by formatDuration in the FailureCard. */
+    duration?: number | null;
   };
 };
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+echo "Starting deployment process..."
+
+echo "Pulling latest changes from Git..."
+git pull origin main
+
+echo "Building Client..."
+cd client
+npm install
+npm run build
+cd ..
+
+echo "Building Server..."
+cd server
+npm install
+npm run build
+cd ..
+
+echo "Restarting PM2 process..."
+pm2 restart qa-dashboard
+
+echo "Update complete! System is up and running."

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -47,6 +47,10 @@ The frontend (`client/src/services/apiService.ts`) calls the API via the relativ
 | GET | `/api/alma-oops` | Legacy "Alma oops" failures (FATAL + "Message appear") |
 | GET | `/api/logs/expand` | Parsed/expanded Jenkins log snippet |
 | GET | `/api/test-results` | Test name search (and raw rows when no query) |
+| GET | `/api/notes` | List all failure notes |
+| POST | `/api/notes` | Create a failure note (test-scoped or global) |
+| DELETE | `/api/notes/{id}` | Delete a failure note by id |
+| GET | `/api/notes/migrate-db` | Temporary internal DB-migration utility |
 
 ---
 
@@ -612,6 +616,120 @@ Searches test names (when `q` is provided) or returns raw rows.
 ```
 
 **Response — 200 OK (no `q`)** — up to 50 raw `QA_AUTOMATION.TESTRESULTS` rows (Oracle column shape).
+
+---
+
+## Failure Notes
+
+Free-text notes attached to failures, backed by the `FAILURE_NOTES` table. A note is
+either **test-scoped** (`testName` set → applies to that one test) or **global**
+(`testName` null → applies to every test failing for the same `failureReason`).
+The frontend merges a test's private notes with matching global notes for display.
+
+### Note shape
+
+```json
+{
+  "noteId": 42,
+  "testName": "SynchAndEdit...",
+  "failureReason": "FATAL element not found",
+  "noteContent": "Flaky on SQA02 — tracked in URM-1234",
+  "createdAt": "2026-06-22T00:00:00.000Z"
+}
+```
+
+- `noteId` (number) — DB identity (`NOTE_ID`).
+- `testName` (string | null) — `null` means a general/global reason note.
+- `failureReason` (string) — the failure reason the note belongs to (`FAILURE_REASON`, NOT NULL, max 1000 chars).
+- `noteContent` (string) — the note text (max 2000 chars).
+- `createdAt` (string | null) — ISO timestamp; `null` on the immediate POST response.
+
+---
+
+### GET `/api/notes`
+
+Returns all failure notes (newest first). The frontend groups/merges them client-side.
+
+**Response — 200 OK** — array of note objects (see **Note shape**).
+
+```json
+[
+  { "noteId": 42, "testName": null, "failureReason": "FATAL element not found", "noteContent": "Infra issue URM-1234", "createdAt": "2026-06-22T00:00:00.000Z" }
+]
+```
+
+---
+
+### POST `/api/notes`
+
+Creates a new note.
+
+**Request body**
+
+```json
+{
+  "testName": "SynchAndEdit...",
+  "failureReason": "FATAL element not found",
+  "content": "Flaky — retried green"
+}
+```
+
+- `testName` (string | null, optional) — empty/missing/whitespace is normalized to `null` (a global reason note).
+- `failureReason` (string, **required**, non-empty).
+- `content` (string, **required**, non-empty).
+
+**Rules**
+
+- Multiple notes are allowed for the same `(testName, failureReason)` pair.
+- **Maximum 5 notes per item.** Before inserting, the backend counts existing notes for that exact `(testName | null, failureReason)`; if the count is already ≥ 5 it rejects with `400 Bad Request` and does not insert.
+- The legacy unique constraint on `(TEST_NAME, FAILURE_REASON)` has been **dropped**; the only write limit is the 5-note cap above.
+
+**Response — 201 Created**
+
+```json
+{
+  "noteId": 43,
+  "testName": "SynchAndEdit...",
+  "failureReason": "FATAL element not found",
+  "noteContent": "Flaky — retried green"
+}
+```
+
+**Errors**
+
+- `400 Bad Request` — `{ "error": "failureReason is required" }`
+- `400 Bad Request` — `{ "error": "content is required" }`
+- `400 Bad Request` — `{ "error": "Maximum of 5 notes per item reached." }` (5-note cap)
+- `500 Internal Server Error` — `{ "error": "Internal Server Error" }`
+
+---
+
+### DELETE `/api/notes/{id}`
+
+Deletes a note by its `NOTE_ID`.
+
+**Path params**
+
+- `id` (number, **required**, positive integer).
+
+**Response — 204 No Content** — deleted (empty body).
+
+**Errors**
+
+- `400 Bad Request` — `{ "error": "id must be a positive integer" }`
+- `404 Not Found` — `{ "error": "Note not found: 999" }`
+- `500 Internal Server Error` — `{ "error": "Internal Server Error" }`
+
+---
+
+### GET `/api/notes/migrate-db`
+
+**Temporary internal utility.** One-off endpoint used to migrate / adjust the
+`FAILURE_NOTES` table schema (e.g. dropping the legacy unique constraint, raising
+column sizes). Not part of the stable public contract — intended for operator use
+during deployment and slated for removal once migration is complete.
+
+**Response — 200 OK** — a plain status payload describing the migration outcome.
 
 ---
 

--- a/server/src/controllers/notesController.ts
+++ b/server/src/controllers/notesController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { getNotes, createNote, deleteNote, NoteConflictError } from "../services/notesService";
+import { getNotes, createNote, deleteNote, NoteLimitError } from "../services/notesService";
 
 export const getNotesHandler = async (_req: Request, res: Response) => {
   try {
@@ -34,8 +34,8 @@ export const createNoteHandler = async (req: Request, res: Response) => {
       noteContent: content.trim(),
     });
   } catch (error) {
-    if (error instanceof NoteConflictError) {
-      return res.status(409).json({ error: error.message });
+    if (error instanceof NoteLimitError) {
+      return res.status(400).json({ error: error.message });
     }
     console.error("Error creating note:", error);
     return res.status(500).json({ error: "Internal Server Error" });

--- a/server/src/controllers/notesController.ts
+++ b/server/src/controllers/notesController.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from "express";
+import { getNotes, createNote, deleteNote, NoteConflictError } from "../services/notesService";
+
+export const getNotesHandler = async (_req: Request, res: Response) => {
+  try {
+    const notes = await getNotes();
+    return res.json(notes);
+  } catch (error) {
+    console.error("Error fetching notes:", error);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+
+export const createNoteHandler = async (req: Request, res: Response) => {
+  try {
+    const { testName, failureReason, content } = req.body ?? {};
+
+    // Empty / missing testName → general reason note (NULL in DB).
+    const normalizedTestName =
+      typeof testName === "string" && testName.trim() !== "" ? testName.trim() : null;
+
+    if (typeof failureReason !== "string" || failureReason.trim() === "") {
+      return res.status(400).json({ error: "failureReason is required" });
+    }
+    if (typeof content !== "string" || content.trim() === "") {
+      return res.status(400).json({ error: "content is required" });
+    }
+
+    const noteId = await createNote(normalizedTestName, failureReason.trim(), content.trim());
+    return res.status(201).json({
+      noteId,
+      testName: normalizedTestName,
+      failureReason: failureReason.trim(),
+      noteContent: content.trim(),
+    });
+  } catch (error) {
+    if (error instanceof NoteConflictError) {
+      return res.status(409).json({ error: error.message });
+    }
+    console.error("Error creating note:", error);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+
+export const deleteNoteHandler = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: "id must be a positive integer" });
+    }
+
+    const deleted = await deleteNote(id);
+    if (!deleted) return res.status(404).json({ error: `Note not found: ${id}` });
+
+    return res.status(204).send();
+  } catch (error) {
+    console.error("Error deleting note:", error);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import envsRoutes from "./routes/envsRoutes";
 import commonRoutes from "./routes/commonRoutes";
 import logsRoutes from "./routes/logsRoutes";
 import almaOopsRoutes from "./routes/almaOopsRoutes";
+import notesRoutes from "./routes/notesRoutes";
 import { checkConnection, closePool } from "./db";
 
 dotenv.config();
@@ -24,6 +25,7 @@ app.use("/api/envs", envsRoutes);
 app.use("/api/common-failures", commonRoutes);
 app.use("/api/logs", logsRoutes);
 app.use("/api/alma-oops", almaOopsRoutes);
+app.use("/api/notes", notesRoutes);
 
 app.get("/health", (req: Request, res: Response) => {
   res.json({ status: "OK", system: "Automation Dashboard Backend" });

--- a/server/src/routes/notesRoutes.ts
+++ b/server/src/routes/notesRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { getNotesHandler, createNoteHandler, deleteNoteHandler } from "../controllers/notesController";
+
+const router = Router();
+
+router.get("/", getNotesHandler);
+router.post("/", createNoteHandler);
+router.delete("/:id", deleteNoteHandler);
+
+export default router;

--- a/server/src/services/areaLatestFailedService.ts
+++ b/server/src/services/areaLatestFailedService.ts
@@ -13,6 +13,7 @@ export type LatestFailedTestItem = {
   screenshotLink: string | null;
   almaVersion: string | null;
   buildNumber: number | null;
+  duration: number | null;
 };
 
 export type LatestFailedByServer = {
@@ -41,6 +42,7 @@ WITH latest_run AS (
     PASSED,
     TESTEDON,
     ENDINGTIMEUNIX,
+    TOTALRUNTIME,
     ROW_NUMBER() OVER (
       PARTITION BY TESTNAME
       ORDER BY TESTEDON DESC, NVL(ENDINGTIMEUNIX, 0) DESC
@@ -58,7 +60,8 @@ SELECT
   SCREENSHOTLINK,
   FAILURETEXT,
   TESTEDON,
-  ENDINGTIMEUNIX
+  ENDINGTIMEUNIX,
+  TOTALRUNTIME
 FROM latest_run
 WHERE RN = 1
   AND LOWER(PASSED) = 'false'
@@ -108,6 +111,7 @@ export async function getAreaLatestFailed(
       screenshotLink: (r.SCREENSHOTLINK ?? null) as string | null,
       almaVersion: (r.ALMAVERSION ?? null) as string | null,
       buildNumber: toNumber(r.BUILDNUMBER),
+      duration: toNumber(r.TOTALRUNTIME),
     };
 
     if (!serverMap.has(server)) {

--- a/server/src/services/areaRecentFailuresGroupedService.ts
+++ b/server/src/services/areaRecentFailuresGroupedService.ts
@@ -12,6 +12,7 @@ WITH failures AS (
     TESTNAME,
     TESTEDON,
     ENDINGTIMEUNIX,
+    TOTALRUNTIME,
     SERVER,
     ALMAVERSION,
     BUILDNUMBER,
@@ -158,7 +159,8 @@ FROM (
     lf.ALMAVERSION,
     lf.BUILDNUMBER,
     lf.LOGLINK,
-    lf.SCREENSHOTLINK
+    lf.SCREENSHOTLINK,
+    lf.TOTALRUNTIME
   FROM test_stats s
   LEFT JOIN top_reasons tr ON tr.TESTNAME = s.TESTNAME
   LEFT JOIN last_failure lf ON lf.TESTNAME = s.TESTNAME
@@ -250,6 +252,8 @@ export async function getAreaRecentFailuresGrouped(
         buildNumber: toNumber(r.BUILDNUMBER),
         logLink,
         screenshotLink,
+        // TOTALRUNTIME from Oracle — exposed as `duration` for the FailureCard.
+        duration: toNumber(r.TOTALRUNTIME),
       },
     };
   });

--- a/server/src/services/logParserService.ts
+++ b/server/src/services/logParserService.ts
@@ -14,13 +14,19 @@ function lastN(lines: string[], n: number): string[] {
   return lines.slice(Math.max(0, lines.length - n));
 }
 
-// Extract the block from the testName line down to the FATAL line (inclusive).
+// Error anchors: FATAL plus JVM out-of-memory crashes (which often have no FATAL line).
+const ERROR_MARKERS = ["FATAL", "OutOfMemoryError", "Java heap space"];
+function isErrorLine(line: string): boolean {
+  return ERROR_MARKERS.some((m) => line.includes(m));
+}
+
+// Extract the block from the testName line down to the error line (inclusive).
 function parseBlock(rawText: string, testName: string): { lines: string[]; source: "parsed" | "fallback" } {
   const lines = rawText.split(/\r?\n/);
 
   let fatalIdx = -1;
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i].includes("FATAL")) { fatalIdx = i; break; }
+    if (isErrorLine(lines[i])) { fatalIdx = i; break; }
   }
   if (fatalIdx === -1) return { lines: lastN(lines, 100), source: "fallback" };
 

--- a/server/src/services/notesService.ts
+++ b/server/src/services/notesService.ts
@@ -9,15 +9,14 @@ export type FailureNote = {
   createdAt: string | null;
 };
 
-export class NoteConflictError extends Error {
-  constructor(message = "A note already exists for this test/reason.") {
+export const MAX_NOTES_PER_ITEM = 5;
+
+export class NoteLimitError extends Error {
+  constructor(message = `Maximum of ${MAX_NOTES_PER_ITEM} notes per item reached.`) {
     super(message);
-    this.name = "NoteConflictError";
+    this.name = "NoteLimitError";
   }
 }
-
-// Oracle unique-constraint violation code.
-const ORA_UNIQUE_VIOLATION = 1;
 
 export async function getNotes(): Promise<FailureNote[]> {
   const sql = `
@@ -42,32 +41,38 @@ export async function createNote(
   failureReason: string,
   content: string
 ): Promise<number> {
+  // Multiple notes per (TEST_NAME, FAILURE_REASON) are allowed, capped at 5.
+  const countRes = await execute(
+    `SELECT COUNT(*) AS CNT
+     FROM FAILURE_NOTES
+     WHERE FAILURE_REASON = :failureReason
+       AND ((:testName IS NULL AND TEST_NAME IS NULL) OR TEST_NAME = :testName)`,
+    { failureReason, testName }
+  );
+  const count = Number((countRes.rows?.[0] as any)?.CNT ?? 0);
+  if (count >= MAX_NOTES_PER_ITEM) {
+    throw new NoteLimitError();
+  }
+
   const sql = `
     INSERT INTO FAILURE_NOTES (TEST_NAME, FAILURE_REASON, NOTE_CONTENT)
     VALUES (:testName, :failureReason, :content)
     RETURNING NOTE_ID INTO :noteId
   `;
 
-  try {
-    const res = await execute(
-      sql,
-      {
-        testName,
-        failureReason,
-        content,
-        noteId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      { autoCommit: true }
-    );
+  const res = await execute(
+    sql,
+    {
+      testName,
+      failureReason,
+      content,
+      noteId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+    },
+    { autoCommit: true }
+  );
 
-    const outBinds = res.outBinds as { noteId: number[] } | undefined;
-    return Number(outBinds?.noteId?.[0]);
-  } catch (err: any) {
-    if (err?.errorNum === ORA_UNIQUE_VIOLATION) {
-      throw new NoteConflictError();
-    }
-    throw err;
-  }
+  const outBinds = res.outBinds as { noteId: number[] } | undefined;
+  return Number(outBinds?.noteId?.[0]);
 }
 
 export async function deleteNote(id: number): Promise<boolean> {

--- a/server/src/services/notesService.ts
+++ b/server/src/services/notesService.ts
@@ -1,0 +1,77 @@
+import oracledb from "oracledb";
+import { execute } from "../db";
+
+export type FailureNote = {
+  noteId: number;
+  testName: string | null;
+  failureReason: string;
+  noteContent: string;
+  createdAt: string | null;
+};
+
+export class NoteConflictError extends Error {
+  constructor(message = "A note already exists for this test/reason.") {
+    super(message);
+    this.name = "NoteConflictError";
+  }
+}
+
+// Oracle unique-constraint violation code.
+const ORA_UNIQUE_VIOLATION = 1;
+
+export async function getNotes(): Promise<FailureNote[]> {
+  const sql = `
+    SELECT NOTE_ID, TEST_NAME, FAILURE_REASON, NOTE_CONTENT, CREATED_AT
+    FROM FAILURE_NOTES
+    ORDER BY CREATED_AT DESC
+  `;
+  const res = await execute(sql, {});
+  const rows = (res.rows ?? []) as any[];
+
+  return rows.map((r) => ({
+    noteId: Number(r.NOTE_ID),
+    testName: (r.TEST_NAME ?? null) as string | null,
+    failureReason: String(r.FAILURE_REASON ?? ""),
+    noteContent: String(r.NOTE_CONTENT ?? ""),
+    createdAt: r.CREATED_AT ? new Date(r.CREATED_AT).toISOString() : null,
+  }));
+}
+
+export async function createNote(
+  testName: string | null,
+  failureReason: string,
+  content: string
+): Promise<number> {
+  const sql = `
+    INSERT INTO FAILURE_NOTES (TEST_NAME, FAILURE_REASON, NOTE_CONTENT)
+    VALUES (:testName, :failureReason, :content)
+    RETURNING NOTE_ID INTO :noteId
+  `;
+
+  try {
+    const res = await execute(
+      sql,
+      {
+        testName,
+        failureReason,
+        content,
+        noteId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+      },
+      { autoCommit: true }
+    );
+
+    const outBinds = res.outBinds as { noteId: number[] } | undefined;
+    return Number(outBinds?.noteId?.[0]);
+  } catch (err: any) {
+    if (err?.errorNum === ORA_UNIQUE_VIOLATION) {
+      throw new NoteConflictError();
+    }
+    throw err;
+  }
+}
+
+export async function deleteNote(id: number): Promise<boolean> {
+  const sql = `DELETE FROM FAILURE_NOTES WHERE NOTE_ID = :id`;
+  const res = await execute(sql, { id }, { autoCommit: true });
+  return (res.rowsAffected ?? 0) > 0;
+}

--- a/server/src/tests/logParser.test.ts
+++ b/server/src/tests/logParser.test.ts
@@ -37,6 +37,46 @@ describe("logParserService.expandLog", () => {
     }
   });
 
+  it("anchors on 'Java heap space' (OOM crash without a FATAL line)", async () => {
+    const raw = [
+      "preamble line",
+      "Running TESTNAME_X now",
+      "doing stuff",
+      "java.lang.OutOfMemoryError: Java heap space",
+      "trailing line",
+    ].join("\n");
+    mockFetch(raw);
+
+    const result = await expandLog("http://jenkins/job/A/1/heap-space", "TESTNAME_X");
+
+    expect(result.available).toBe(true);
+    if (result.available) {
+      expect(result.source).toBe("parsed");
+      expect(result.lines).toEqual([
+        "Running TESTNAME_X now",
+        "doing stuff",
+        "java.lang.OutOfMemoryError: Java heap space",
+      ]);
+    }
+  });
+
+  it("anchors on 'OutOfMemoryError'", async () => {
+    const raw = [
+      "Running TESTNAME_Y now",
+      "allocating buffers",
+      "java.lang.OutOfMemoryError: GC overhead limit exceeded",
+    ].join("\n");
+    mockFetch(raw);
+
+    const result = await expandLog("http://jenkins/job/A/1/oom", "TESTNAME_Y");
+
+    expect(result.available).toBe(true);
+    if (result.available) {
+      expect(result.source).toBe("parsed");
+      expect(result.lines[result.lines.length - 1]).toContain("OutOfMemoryError");
+    }
+  });
+
   it("falls back to the last 100 lines when no FATAL is present", async () => {
     const raw = Array.from({ length: 150 }, (_, i) => `log line ${i + 1}`).join("\n");
     mockFetch(raw);

--- a/server/src/tests/notesController.test.ts
+++ b/server/src/tests/notesController.test.ts
@@ -1,0 +1,133 @@
+jest.mock("../services/notesService", () => {
+  class NoteLimitError extends Error {}
+  return {
+    getNotes: jest.fn(),
+    createNote: jest.fn(),
+    deleteNote: jest.fn(),
+    NoteLimitError,
+  };
+});
+
+import { Request, Response } from "express";
+import { getNotes, createNote, deleteNote, NoteLimitError } from "../services/notesService";
+import { getNotesHandler, createNoteHandler, deleteNoteHandler } from "../controllers/notesController";
+
+const mockGet = getNotes as jest.Mock;
+const mockCreate = createNote as jest.Mock;
+const mockDelete = deleteNote as jest.Mock;
+
+function mockRes() {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("getNotesHandler", () => {
+  it("returns 200 with the notes", async () => {
+    mockGet.mockResolvedValue([{ noteId: 1 }]);
+    const res = mockRes();
+    await getNotesHandler({} as Request, res);
+    expect(res.json).toHaveBeenCalledWith([{ noteId: 1 }]);
+  });
+
+  it("returns 500 when the service throws", async () => {
+    mockGet.mockRejectedValue(new Error("boom"));
+    const res = mockRes();
+    await getNotesHandler({} as Request, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("createNoteHandler", () => {
+  it("creates a note and returns 201", async () => {
+    mockCreate.mockResolvedValue(55);
+    const req = { body: { testName: "T1", failureReason: "FATAL", content: "hi" } } as Request;
+    const res = mockRes();
+
+    await createNoteHandler(req, res);
+
+    expect(mockCreate).toHaveBeenCalledWith("T1", "FATAL", "hi");
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ noteId: 55, testName: "T1" }));
+  });
+
+  it("normalizes empty testName to null (global note)", async () => {
+    mockCreate.mockResolvedValue(1);
+    const req = { body: { testName: "   ", failureReason: "FATAL", content: "global" } } as Request;
+    const res = mockRes();
+
+    await createNoteHandler(req, res);
+
+    expect(mockCreate).toHaveBeenCalledWith(null, "FATAL", "global");
+  });
+
+  it("returns 400 when failureReason is missing", async () => {
+    const req = { body: { content: "hi" } } as Request;
+    const res = mockRes();
+    await createNoteHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const req = { body: { failureReason: "FATAL" } } as Request;
+    const res = mockRes();
+    await createNoteHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns 400 when the 5-note limit is exceeded", async () => {
+    mockCreate.mockRejectedValue(new NoteLimitError("Maximum of 5 notes per item reached."));
+    const req = { body: { testName: "T1", failureReason: "FATAL", content: "6th" } } as Request;
+    const res = mockRes();
+
+    await createNoteHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringMatching(/5 notes/i) }));
+  });
+
+  it("returns 500 on an unexpected service error", async () => {
+    mockCreate.mockRejectedValue(new Error("db down"));
+    const req = { body: { testName: "T1", failureReason: "FATAL", content: "x" } } as Request;
+    const res = mockRes();
+    await createNoteHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("deleteNoteHandler", () => {
+  it("returns 204 when a note is deleted", async () => {
+    mockDelete.mockResolvedValue(true);
+    const req = { params: { id: "5" } } as unknown as Request;
+    const res = mockRes();
+
+    await deleteNoteHandler(req, res);
+
+    expect(mockDelete).toHaveBeenCalledWith(5);
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it("returns 404 when the note does not exist", async () => {
+    mockDelete.mockResolvedValue(false);
+    const req = { params: { id: "999" } } as unknown as Request;
+    const res = mockRes();
+    await deleteNoteHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("returns 400 for a non-positive id", async () => {
+    const req = { params: { id: "abc" } } as unknown as Request;
+    const res = mockRes();
+    await deleteNoteHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/tests/notesService.test.ts
+++ b/server/src/tests/notesService.test.ts
@@ -1,0 +1,85 @@
+jest.mock("../db", () => ({ execute: jest.fn() }));
+
+import { execute } from "../db";
+import { getNotes, createNote, deleteNote, NoteLimitError, MAX_NOTES_PER_ITEM } from "../services/notesService";
+
+const mockExecute = execute as jest.Mock;
+
+beforeEach(() => mockExecute.mockReset());
+
+describe("notesService.getNotes", () => {
+  it("maps DB rows into FailureNote objects", async () => {
+    mockExecute.mockResolvedValue({
+      rows: [
+        {
+          NOTE_ID: 7,
+          TEST_NAME: "MyTest",
+          FAILURE_REASON: "FATAL boom",
+          NOTE_CONTENT: "look into URM-1",
+          CREATED_AT: new Date("2026-06-22T00:00:00Z"),
+        },
+        { NOTE_ID: 8, TEST_NAME: null, FAILURE_REASON: "FATAL boom", NOTE_CONTENT: "global", CREATED_AT: null },
+      ],
+    });
+
+    const notes = await getNotes();
+
+    expect(notes).toHaveLength(2);
+    expect(notes[0]).toMatchObject({ noteId: 7, testName: "MyTest", failureReason: "FATAL boom", noteContent: "look into URM-1" });
+    expect(notes[1]).toMatchObject({ noteId: 8, testName: null, createdAt: null });
+  });
+
+  it("returns an empty array when there are no rows", async () => {
+    mockExecute.mockResolvedValue({ rows: [] });
+    expect(await getNotes()).toEqual([]);
+  });
+});
+
+describe("notesService.createNote", () => {
+  it("inserts and returns the new noteId when under the limit", async () => {
+    mockExecute
+      .mockResolvedValueOnce({ rows: [{ CNT: 2 }] })          // count query
+      .mockResolvedValueOnce({ outBinds: { noteId: [99] } });  // insert
+
+    const id = await createNote("MyTest", "FATAL boom", "note text");
+
+    expect(id).toBe(99);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    // The INSERT runs with autoCommit.
+    const insertCall = mockExecute.mock.calls[1];
+    expect(insertCall[0]).toMatch(/INSERT INTO FAILURE_NOTES/i);
+    expect(insertCall[2]).toEqual(expect.objectContaining({ autoCommit: true }));
+  });
+
+  it("normalizes the count query for a global (null testName) note", async () => {
+    mockExecute
+      .mockResolvedValueOnce({ rows: [{ CNT: 0 }] })
+      .mockResolvedValueOnce({ outBinds: { noteId: [1] } });
+
+    await createNote(null, "FATAL boom", "global note");
+
+    const countBinds = mockExecute.mock.calls[0][1];
+    expect(countBinds).toEqual(expect.objectContaining({ testName: null, failureReason: "FATAL boom" }));
+  });
+
+  it(`throws NoteLimitError and does NOT insert at the ${MAX_NOTES_PER_ITEM}-note cap`, async () => {
+    mockExecute.mockResolvedValueOnce({ rows: [{ CNT: MAX_NOTES_PER_ITEM }] }); // already at cap
+
+    await expect(createNote("MyTest", "FATAL boom", "one too many")).rejects.toBeInstanceOf(NoteLimitError);
+    // Only the count query ran — no INSERT.
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("notesService.deleteNote", () => {
+  it("returns true when a row was deleted", async () => {
+    mockExecute.mockResolvedValue({ rowsAffected: 1 });
+    expect(await deleteNote(5)).toBe(true);
+    expect(mockExecute.mock.calls[0][2]).toEqual(expect.objectContaining({ autoCommit: true }));
+  });
+
+  it("returns false when nothing matched", async () => {
+    mockExecute.mockResolvedValue({ rowsAffected: 0 });
+    expect(await deleteNote(404)).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request introduces several improvements to the test failure UI, focusing on enhancing the notes and annotation experience, improving usability in the "By Reason" view, and refining the display of test failure details. The changes include a unified inline notes component, better grouping and propagation of notes in different views, new UI controls for adding notes, and additional conveniences like copying test names and displaying test durations.

**Notes and Annotation Improvements:**

* Replaced the previous `TestNoteButton` and `TestNoteDisplay` components with a unified `InlineNotes` component across `FailureCard`, `FailureRowList`, and `ByReasonView`, allowing users to add and view notes inline for both individual tests and grouped reasons. Notes now propagate correctly in the "By Reason" view, supporting both global (reason-level) and test-specific notes. [[1]](diffhunk://#diff-bc667acd00f52e63e5c7b440087d35f077a412df7d68f222ff46c3fdcc5f0bcfR61-R100) [[2]](diffhunk://#diff-bc667acd00f52e63e5c7b440087d35f077a412df7d68f222ff46c3fdcc5f0bcfR109-R114) [[3]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396R53-R57) [[4]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396R118-R124) [[5]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396R139-R158) [[6]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396L205) [[7]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396L217-R252) [[8]](diffhunk://#diff-9d0349b84cc311abdc9e0c918c2187fb71f97cce6a1270a22b372abbfa53b17bL2-R8) [[9]](diffhunk://#diff-9d0349b84cc311abdc9e0c918c2187fb71f97cce6a1270a22b372abbfa53b17bR18-R24) [[10]](diffhunk://#diff-9d0349b84cc311abdc9e0c918c2187fb71f97cce6a1270a22b372abbfa53b17bL50-R74)

* Added an "Add note" button and icon to the right of each reason group in the "By Reason" view, which expands the accordion and opens the note editor for that reason.

**Usability and UI Enhancements:**

* Added a "Copy test name" icon button to each row in the `FailureRowList`, allowing users to quickly copy test names to the clipboard.

* Improved the display of pass rates in `AreaCard` to show the exact pass rate of the latest day, matching the rightmost plotted point in the trend chart. [[1]](diffhunk://#diff-ee8bd3c05c03e9927bee0017559c67ab98f7719270a5b78342e787762bd35552R53-R63) [[2]](diffhunk://#diff-ee8bd3c05c03e9927bee0017559c67ab98f7719270a5b78342e787762bd35552L87-R95)

**Additional Failure Details:**

* Displayed test duration (runtime) in the failure card, styled to match the date element, and included an icon for clarity. [[1]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396R40) [[2]](diffhunk://#diff-c0c5a02de92b1eb4d8c0b693d0f9e49dbaf0f92c839718352ec8cc80c738c396L230-R280)

* Updated date formatting in failure details to use a more precise date-time format.

**Configuration and Environment:**

* Added a new `VITE_JIRA_BASE_URL` variable to `.env.example` for configuring clickable JIRA ticket links in notes.